### PR TITLE
Add cleric spell slots

### DIFF
--- a/dungeonsheets/character.py
+++ b/dungeonsheets/character.py
@@ -60,7 +60,7 @@ class Character():
     nature = Skill(ability='intelligence')
     perception = Skill(ability='wisdom')
     performance = Skill(ability='charisma')
-    persuasion = Skill(ability='charisma')
+    persuasian = Skill(ability='charisma')
     religion = Skill(ability='intelligence')
     sleight_of_hand = Skill(ability='dexterity')
     stealth = Skill(ability='dexterity')

--- a/dungeonsheets/character.py
+++ b/dungeonsheets/character.py
@@ -60,7 +60,7 @@ class Character():
     nature = Skill(ability='intelligence')
     perception = Skill(ability='wisdom')
     performance = Skill(ability='charisma')
-    persuasian = Skill(ability='charisma')
+    persuasion = Skill(ability='charisma')
     religion = Skill(ability='intelligence')
     sleight_of_hand = Skill(ability='dexterity')
     stealth = Skill(ability='dexterity')
@@ -340,9 +340,32 @@ class Cleric(Character):
     saving_throw_proficiencies = ('wisdom', 'charisma')
     _proficiencies_text = ('light armor', 'medium armor', 'shields',
                           'all simple weapons')
-    weapon_proficiencies = weapons.simple_weapons
     class_skill_choices = ('History', 'Insight', 'Medicine',
                            'Persuasion', 'Religion')
+    weapon_proficiencies = weapons.simple_weapons
+    spellcasting_ability = 'charisma'
+    spell_slots_by_level = {
+        1:  (3, 2, 0, 0, 0, 0, 0, 0, 0, 0),
+        2:  (0, 1, 0, 0, 0, 0, 0, 0, 0, 0),
+        3:  (3, 1, 2, 0, 0, 0, 0, 0, 0, 0),
+        4:  (1, 0, 1, 0, 0, 0, 0, 0, 0, 0),
+        5:  (0, 0, 0, 2, 0, 0, 0, 0, 0, 0),
+        6:  (0, 0, 0, 1, 0, 0, 0, 0, 0, 0),
+        7:  (0, 0, 0, 0, 1, 0, 0, 0, 0, 0),
+        8:  (0, 0, 0, 0, 1, 0, 0, 0, 0, 0),
+        9:  (0, 0, 0, 0, 1, 1, 0, 0, 0, 0),
+        10: (0, 0, 0, 0, 0, 1, 0, 0, 0, 0),
+        11: (0, 0, 0, 0, 0, 0, 1, 0, 0, 0),
+        12: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+        13: (0, 0, 0, 0, 0, 0, 0, 1, 0, 0),
+        14: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+        15: (0, 0, 0, 0, 0, 0, 0, 0, 1, 0),
+        16: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+        17: (0, 0, 0, 0, 0, 0, 0, 0, 0, 1),
+        18: (0, 0, 0, 0, 0, 1, 0, 0, 0, 0),
+        19: (0, 0, 0, 0, 0, 0, 1, 0, 0, 0),
+        20: (0, 0, 0, 0, 0, 0, 0, 1, 0, 0),
+    }
 
 
 class Druid(Character):


### PR DESCRIPTION
Took the source for this from the [roll20 Cleric page](https://roll20.net/compendium/dnd5e/Cleric#toc_3)

- adds Cleric spell slots to `character.py`