### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.7-alpine
+
+RUN apk add --no-cache pdftk texlive
+
+WORKDIR /tmp
+
+COPY ./ ./
+
+RUN python setup.py install
+
+WORKDIR /examples
+
+ENTRYPOINT [ "makesheets" ]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: help 
+
+.DEFAULT: help
+
+help:
+	@echo "Make Help"
+	@echo "Create a character sheet from examples/warlock.py:"
+	@echo "\tmake sheet character=warlock "
+
+sheet:
+	@[ ! -z $(character) ] || { echo "ERROR: \"character\" variable was not set.\n\n" && make help && exit 1; }
+	CHARACTER=$(character) docker-compose up
+
+

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Installation
 .. _f-strings: https://www.python.org/dev/peps/pep-0498/
 
 Optional External dependencies
-==============================
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * You may use **pdftk** to generate the sheets in PDF format.
 * You will need **pdflatex** installed to generate the PDF spell pages (optional).
@@ -73,3 +73,28 @@ so attack bonuses and damage can be calculated automatically.
 If you'd like a **step-by-step walkthrough** for creating a new
 character, just run ``create-character`` from a command line and a
 helpful menu system will take care of the basics for you.
+
+
+Using Docker
+~~~~~~~~~~~~
+
+To create the ``examples/warlock.pdf`` character sheet from 
+``examples/warlock.py``, run the following at the root of the 
+repository:
+
+.. code:: bash
+
+    $ make sheet character=warlock
+
+**Requirements**
+
+The Dockerfile included in this repository will create an image
+with the aforementioned dependices but you need to install the 
+following:
+
+- Docker_
+- Docker-Compose_
+- GNU Make
+
+.. _Docker: https://docs.docker.com/install/
+.. _Docker-Compose: https://docs.docker.com/compose/install/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+
+  dungeonsheets:
+    build: ./
+    volumes:
+      - ./examples:/examples
+    command: ${CHARACTER}.py
+    entrypoint: makesheets 


### PR DESCRIPTION
This PR adds support to build character sheets with a Docker image. It allows a user to checkout the repository and run `make sheet character=warlock` to build the Docker image and create the player sheet. 