### PR TITLE
Added Kalashtar Race from Eberron: RFTLW

### DIFF
--- a/dungeonsheets/features/races.py
+++ b/dungeonsheets/features/races.py
@@ -711,3 +711,54 @@ class CallToTheWave(Feature):
     """
     name = "Call to the Wave"
     source = "Race (Water Genasi)"
+
+# RFTLW Races
+
+class DualMind(Feature)
+    """
+    You have advantage on all Wisdom saving throws.
+    
+    """
+    name = "Dual Mind"
+    source = "Race (Kalashtar)"
+
+class MentalDiscipline(Feature)
+    """
+    You have resistance to psychic damage.
+    
+    """
+    name = "Mental Discipline"
+    source = "Race (Kalashtar)"
+
+class MindLink(Feature)
+    """
+    You can speak telepathically to any creature you can see, provided
+    the creature is within a number of feet of you equal to 10 times your
+    level. You don’t need to share a language with the creature for it to
+    understand your telepathic utterances, but the creature must be able
+    to understand at least one language.
+
+    When you’re using this trait to speak telepathically to a creature,
+    you can use your action to give that creature the ability to speak
+    telepathically with you for 1 hour or until you end this effect as
+    an action. To use this ability, the creature must be able to see
+    you and must be within this trait’s range. You can give this
+    ability to only one creature at a time; giving it to a creature
+    takes it away from another creature who has it.  
+
+    """
+    name = "Mind Link"
+    source = "Race (Kalashtar)"
+
+class SeveredFromDreams(Feature)
+    """
+    Kalashtar sleep, but they don't connect to the plane of dreams as
+    other creatures do. Instead, their minds draw from the memories of
+    the otherworldly spirit while they sleep. As such, you are immune
+    to spells and other magical effects that require you to dream,
+    like 'dream', but not to spells and other magical effects that put
+    you to sleep, like 'sleep'.
+
+    """
+    name = "Severed from Dreams"
+    source = "Race (Kalashtar)"

--- a/dungeonsheets/features/races.py
+++ b/dungeonsheets/features/races.py
@@ -714,7 +714,7 @@ class CallToTheWave(Feature):
 
 # RFTLW Races
 
-class DualMind(Feature)
+class DualMind(Feature):
     """
     You have advantage on all Wisdom saving throws.
     
@@ -722,7 +722,7 @@ class DualMind(Feature)
     name = "Dual Mind"
     source = "Race (Kalashtar)"
 
-class MentalDiscipline(Feature)
+class MentalDiscipline(Feature):
     """
     You have resistance to psychic damage.
     
@@ -730,7 +730,7 @@ class MentalDiscipline(Feature)
     name = "Mental Discipline"
     source = "Race (Kalashtar)"
 
-class MindLink(Feature)
+class MindLink(Feature):
     """
     You can speak telepathically to any creature you can see, provided
     the creature is within a number of feet of you equal to 10 times your
@@ -750,7 +750,7 @@ class MindLink(Feature)
     name = "Mind Link"
     source = "Race (Kalashtar)"
 
-class SeveredFromDreams(Feature)
+class SeveredFromDreams(Feature):
     """
     Kalashtar sleep, but they don't connect to the plane of dreams as
     other creatures do. Instead, their minds draw from the memories of

--- a/dungeonsheets/race.py
+++ b/dungeonsheets/race.py
@@ -414,6 +414,16 @@ class WaterGenasi(_Genasi):
     features = (feats.AcidResistance, feats.Amphibious,
                 feats.CallToTheWave)
 
+# Eberron Races
+class Kalashtar(Race):
+    name = "Kalashtar"
+    wisdom_bonus = 2
+    charisma_bonus = 1
+    size = 'medium'
+    speed = 30
+    languages = ("Common", "Quori",) # Not sure how to have a "+1 language of your choice" - naviabbot
+    features = (feats.DualMind, feats.MentalDiscipline, feats.MindLink, feats.SeveredFromDreams)
+
 
 PHB_races = [HillDwarf, MountainDwarf, HighElf, WoodElf, DarkElf,
              LightfootHalfling, StoutHalfling, Human, Dragonborn,
@@ -425,7 +435,9 @@ VOLO_races = [ProtectorAasimar, ScourgeAasimar, FallenAasimar,
 EE_races = [Aarakocra, DeepGnome, AirGenasi, FireGenasi, EarthGenasi,
             WaterGenasi]
 
-available_races = PHB_races + VOLO_races + EE_races
+RFTLW_races = [Kalashtar]
+
+available_races = PHB_races + VOLO_races + EE_races + RFTLW_races
 
 __all__ = tuple([r.name for r in available_races]) + (
-    'available_races', 'PHB_races', 'VOLO_races', 'EE_races')
+    'available_races', 'PHB_races', 'VOLO_races', 'EE_races, RFTLW_races')


### PR DESCRIPTION
Starting to add things in from Eberron: Rise from the Last War. There are a lot of options that are chosen at race selection, such as certain racial ability score bonuses. The Kalashtar race just seemed the most easiest to work with, seeing as it was the most straight forward to port from book to dungeon-sheets.