### PR TITLE
fix reroll max hp

### DIFF
--- a/dungeonsheets/create_character.py
+++ b/dungeonsheets/create_character.py
@@ -125,7 +125,7 @@ class App(npyscreen.NPSAppManaged):
             if i == 0:
                 num -= 1
             for d in range(num):
-                hp_max += randint(low=1, high=hd.faces+1) + const
+                hp_max += randint(1, hd.faces) + const
         abil.hp_max.value = str(hp_max)
         abil.display()
 


### PR DESCRIPTION
This commit fixes a bug that occured in create-character menu.
The 'reroll max hp' option crashed due to invalid parameters of
function.