### PR TITLE
Fix Artificer Magical Tinkering description

### DIFF
--- a/dungeonsheets/features/artificer.py
+++ b/dungeonsheets/features/artificer.py
@@ -84,27 +84,27 @@ class MagicalTinkering(Feature):
     artisan's tools  in hand. You then touch a Tiny nonmagical object as an
     action and give it one of the following magical properties of your choice:
 
-    - The object sheds bright light in a 5-foot radius and dim light for an
-      additional 5 fe et.
+    - The object sheds bright light in a 5-foot radius and dim light for an \
+      additional 5 feet.
 
-    - Whenever tapped by a creature, the object emits a recorded message that
-      can be heard up to 10 feet away. You utter the message when you bestow
-      this property on the object, and the recording can be no more than 6
+    - Whenever tapped by a creature, the object emits a recorded message that \
+      can be heard up to 10 feet away. You utter the message when you bestow \
+      this property on the object, and the recording can be no more than 6 \
       seconds long.
 
-    - The object continuously emits your choice of an odor or a nonverbal sound
-      (wind, waves, chirping, or the like). The chosen phenomenon is
+    - The object continuously emits your choice of an odor or a nonverbal sound \
+      (wind, waves, chirping, or the like). The chosen phenomenon is \
       perceivable up to 10 feet away.
 
-    - A static visual effect appears on one of the object's surfaces. This
-      effect can be a picture, up to 25 words of text, lines and shapes, or a
-      mixture of these elements, as you like. The chosen property lasts
-      indefinitely. As an action, you can touch the object and end the property
-      early. You can bestow magic on multiple objects, touching one object each
-      time you use this feature, though a single object can only bear one
-      property at a time. The maximum number of objects you can affect with
-      this feature at one time is equal to your Intelligence modifier (minimum
-      of one object). If you try to exceed your maximum, the oldest property
+    - A static visual effect appears on one of the object's surfaces. This \
+      effect can be a picture, up to 25 words of text, lines and shapes, or a \
+      mixture of these elements, as you like. The chosen property lasts \
+      indefinitely. As an action, you can touch the object and end the property \
+      early. You can bestow magic on multiple objects, touching one object each \
+      time you use this feature, though a single object can only bear one \
+      property at a time. The maximum number of objects you can affect with \
+      this feature at one time is equal to your Intelligence modifier (minimum \
+      of one object). If you try to exceed your maximum, the oldest property \
       immediately ends, and then the new property applies.
     """
 


### PR DESCRIPTION
Add backticks to prevent latex from breaking the intended formatting.