### PR TITLE
Fix catapult spell

### DIFF
--- a/dungeonsheets/spells/spells_c.py
+++ b/dungeonsheets/spells/spells_c.py
@@ -90,7 +90,7 @@ class Catapult(Spell):
     name = "Catapult"
     level = 1
     casting_time = "1 action"
-    casting_range = "150 feet"
+    casting_range = "60 feet"
     components = ("S",)
     materials = ""
     duration = "Instantaneous"


### PR DESCRIPTION
Range on catapult should be 60 feet. From [dndbeyond](https://www.dndbeyond.com/spells/catapult).