### PR TITLE
Add Github actions testing

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -34,10 +34,11 @@ jobs:
         echo "$(kpsewhich -var-value TEXMFHOME)/tex/latex/"
         mkdir -p "$(kpsewhich -var-value TEXMFHOME)/tex/latex/"
         git clone https://github.com/rpgtex/DND-5e-LaTeX-Template.git "$(kpsewhich -var-value TEXMFHOME)/tex/latex/dnd"
+    - name: Run flake
+      run: flake8 dungeonsheets/ --exit-zero
     - name: Run tests
       run: |
           pytest --cov=dungeonsheets tests/
-          flake8 dungeonsheets/ --exit-zero
           cd examples/
           makesheets --debug
           makesheets --debug --fancy

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -37,10 +37,10 @@ jobs:
     - name: Run flake
       run: flake8 dungeonsheets/ --exit-zero
     - name: Run tests
-      run: |
+      run: >
+          cd examples/;
+          makesheets --debug;
+          makesheets --debug --fancy;
+          makesheets --debug --output-format=epub;
+          cd ../;
           pytest --cov=dungeonsheets tests/
-          cd examples/
-          makesheets --debug
-          makesheets --debug --fancy
-          makesheets --debug --output-format=epub
-      continue-on-error: true

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,45 @@
+name: Python package
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up required system dependencies
+      run: apt-get -y install pdftk texlive-latex-base texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4.0.0
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: pip
+    - name: Install dependencies and do a local pip install
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-tests.txt
+        pip install -e .
+    - name: Install DnD LaTeX styles
+      run: |
+        echo "$(kpsewhich -var-value TEXMFHOME)/tex/latex/"
+        mkdir -p "$(kpsewhich -var-value TEXMFHOME)/tex/latex/"
+        git clone https://github.com/rpgtex/DND-5e-LaTeX-Template.git "$(kpsewhich -var-value TEXMFHOME)/tex/latex/dnd"
+    - name: Run tests
+      run: |
+          pytest --cov=dungeonsheets tests/
+          flake8 dungeonsheets/ --exit-zero
+          cd examples/
+          makesheets --debug
+          makesheets --debug --fancy
+          makesheets --debug --output-format=epub
+      continue-on-error: true

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up required system dependencies
-      run: apt-get -y install pdftk texlive-latex-base texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra
+      run: sudo apt-get -y install pdftk texlive-latex-base texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4.0.0
       with:


### PR DESCRIPTION
This converts the existing travis CI to Github CI, possibly closing #108. I plan on possibly submitting more PRs, so set this up on my fork to test my edits and thought it could be useful here! Github actions are free for public repos too :)

## Notes
- The flake run shows a lot of warnings, so not sure if this correctly pulls in any necessary flake config.
- Coveralls is not setup because I don't have a coveralls instance but it should be fairly easy to setup; I have used codecov before through GHA and all you really need is a three-line step at the end. It looks like Coveralls needs `GITHUB_TOKEN` set so it can comment on PRs.

```
    - name: Coveralls
      if: always()
      uses: coverallsapp/github-action@master
      with:
        github-token: ${{ secrets.GITHUB_TOKEN }}
```
The `if: always()` line means that we can "fail the GHA build" with a failing test, but it will still always upload coverage to Coveralls.
