### PR TITLE
Fix racial proficiencies bug

### DIFF
--- a/dungeonsheets/race.py
+++ b/dungeonsheets/race.py
@@ -15,7 +15,7 @@ class Race:
     owner = None
     languages = ("Common",)
     proficiencies_text = tuple()
-    weapon_proficiences = tuple()
+    weapon_proficiencies = tuple()
     skill_proficiencies = ()
     skill_choices = ()
     num_skill_choices = 0
@@ -61,7 +61,7 @@ class _Dwarf(Race):
     languages = ("Common", "Dwarvish")
     constitution_bonus = 2
     proficiencies_text = ("battleaxes", "handaxes", "throwing hammers", "warhammers")
-    weapon_proficiences = (
+    weapon_proficiencies = (
         weapons.Battleaxe,
         weapons.Handaxe,
         weapons.ThrowingHammer,
@@ -388,7 +388,7 @@ class Tabaxi(Race):
     speed = "30 (20 climb)"
     languages = ("Common", "[Choose One]")
     weapon_proficiencies = (weapons.Claws,)
-    proficiences_text = ("Claws",)
+    proficiencies_text = ("Claws",)
     skill_proficiencies = ("perception", "stealth")
     features = (
         feats.Darkvision,
@@ -427,7 +427,7 @@ class Aarakocra(Race):
     wisdom_bonus = 1
     languages = ("Common", "Aarakocra", "Auran")
     weapon_proficiencies = (weapons.Talons,)
-    proficiences_text = ("Talons",)
+    proficiencies_text = ("Talons",)
 
     def __init__(self, owner=None):
         super().__init__(owner=owner)

--- a/dungeonsheets/readers.py
+++ b/dungeonsheets/readers.py
@@ -500,14 +500,14 @@ class FoundryCharacterReader(JSONCharacterReader):
             "cha": "charisma",
         }
         abilities = self.json_data()["data"]["abilities"]
-        save_proficiences = []
+        save_proficiencies = []
         for abbr, attr in attribute_names.items():
             char_props[attr] = self.as_int(abilities[abbr]["value"])
             # Check proficiency
             is_proficient = bool(abilities[abbr]["proficient"])
             if is_proficient:
-                save_proficiences.append(attr)
-        char_props["saving_throw_proficiencies"] = save_proficiences
+                save_proficiencies.append(attr)
+        char_props["saving_throw_proficiencies"] = save_proficiencies
         # Skill proficiencies
         skill_names = [
             "acrobatics",

--- a/tests/test_character.py
+++ b/tests/test_character.py
@@ -9,7 +9,7 @@ from dungeonsheets.character import (
     Wizard,
     Druid,
 )
-from dungeonsheets.weapons import Weapon, Shortsword
+from dungeonsheets.weapons import Weapon, Shortsword, Battleaxe
 from dungeonsheets.magic_items import MagicItem
 from dungeonsheets.armor import Armor, LeatherArmor, Shield
 
@@ -149,6 +149,11 @@ class TestCharacter(TestCase):
         char.weapon_proficiencies = tuple()
         char.race = race.HighElf()
         self.assertTrue(char.is_proficient(sword))
+    
+    def test_racial_is_proficient(self):
+        char = Character(classes=["Wizard"], race="Mountain Dwarf")
+        battleaxe = Battleaxe()
+        self.assertTrue(char.is_proficient(battleaxe))
 
     def test_proficiencies_text(self):
         char = Character()


### PR DESCRIPTION
Previously, there were misspellings in `race.py`, which then caused racial weapon proficiencies (specifically for dwarves) to not be picked up. I've added a test that tests this and fixed the misspellings, which causes the test to pass.