### PR TITLE
Updated Jack of All Trades to apply to initiative rolls

### DIFF
--- a/dungeonsheets/stats.py
+++ b/dungeonsheets/stats.py
@@ -310,12 +310,18 @@ class NumericalInitiative:
 
     def __get__(self, actor, Actor):
         ini = actor.dexterity.modifier
+
+        added_proficiency = False
         if actor.has_feature(QuickDraw):
             ini += actor.proficiency_bonus
+            added_proficiency = True
         if actor.has_feature(DreadAmbusher):
             ini += actor.wisdom.modifier
         if actor.has_feature(RakishAudacity):
             ini += actor.charisma.modifier
+        
+        if actor.has_feature(JackOfAllTrades) and not added_proficiency:
+            ini += actor.proficiency_bonus // 2
 
         has_advantage = (
             actor.has_feature(NaturalExplorerRevised)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -69,6 +69,12 @@ class BardTests(TestCase):
         char = character.Character(classes=["bard"], levels=[17])
         sor = bard.SongOfRest(owner=char)
         self.assertEqual(sor.name, "Song of Rest (1d12)")
+    
+    def test_jack_of_all_trades(self):
+        # Test that half of proficiency is added to skill checks w/o the proficiency bonus
+        char = character.Character(classes=["bard"], levels=[2], dexterity=10)
+        self.assertEqual(char.initiative, "+1")
+        self.assertEqual(char.acrobatics.is_jack_of_all_trades, True)
 
     def test_mantle_of_inspiration(self):
         for lvl in range(1, 5):


### PR DESCRIPTION
It looks like Jack of All Trades [should apply](https://media.wizards.com/2019/dnd/downloads/SA-Compendium.pdf#page=9) to initiative rolls, as they are just dexterity checks.

> Don’t forget that initiative rolls are Dexterity checks, so Jack of All Trades can benefit a bard’s initiative, assuming the bard isn’t already adding his or her proficiency bonus to it.

Currently implemented with an added flag because Gunslinger is written to always add the proficiency bonus.