### PR TITLE
Fix small typo in paladin fighting style.

### DIFF
--- a/dungeonsheets/features/paladin.py
+++ b/dungeonsheets/features/paladin.py
@@ -74,7 +74,7 @@ class PaladinFightingStyle(FeatureSelector):
         "dueling": Dueling,
         "great": GreatWeaponFighting,
         "great-weapon fighting": GreatWeaponFighting,
-        "projection": Protection,
+        "protection": Protection,
     }
     name = "Fighting Style (Select One)"
     source = "Paladin"


### PR DESCRIPTION
Paladin's Protection fighting style had a small typo: 'projection' instead of 'protection'.