### PR TITLE
Latex cleanup

### DIFF
--- a/dungeonsheets/forms/features_template.tex
+++ b/dungeonsheets/forms/features_template.tex
@@ -1,25 +1,19 @@
 \pdfbookmark[0]{Features}{Features}
 \section*{Features}
 [% if use_dnd_decorations %]
-  [% for feat in character.features %]
+  [%- for feat in character.features %]
     \pdfbookmark[1]{[[ feat.name ]]}{Features - [[ feat.name ]]}
     \DndFeatHeader{[[ feat.name ]]}[Source: [[ feat.source ]]]
-
-    [[ feat.__doc__|rst_to_latex ]]
-  [% endfor %]
+    [[- feat.__doc__|rst_to_latex -]]
+  [%- endfor -%]
 [% else %]
-  [% for feat in character.features %]
+  [%- for feat in character.features %]
     \pdfbookmark[1]{[[ feat.name ]]}{Features - [[ feat.name ]]}
     \subsection*{[[ feat.name ]]}
-
-    \noindent
     \textbf{Source:} [[ feat.source ]] \\
-
-    [% if feat.needs_implementation %] %
-      \textbf{**Not included in stats on Character Sheet} %
-    [% endif %] %
-              
-    [[ feat.__doc__|rst_to_latex ]]
-
-  [% endfor %]
+    [%- if feat.needs_implementation %]
+      \textbf{**Not included in stats on Character Sheet}
+    [%- endif -%]
+    [[- feat.__doc__|rst_to_latex -]]
+  [%- endfor -%]
 [% endif %]

--- a/dungeonsheets/forms/infusions_template.tex
+++ b/dungeonsheets/forms/infusions_template.tex
@@ -3,20 +3,7 @@
 [% for inf in character.infusions %]
   \pdfbookmark[1]{[[ inf.name ]]}{Infusions - [[ inf.name ]]}
   \subsection*{[[ inf.name ]]}
-
-  [% if inf.prerequisite %]%
-
-		\noindent
-    \textit{Prerequisite: [[ inf.prerequisite ]]}%
-
-  [% endif %]%
-  [% if inf.item %]%
-
-    \noindent
-    \textit{Item: [[ inf.item ]]}%
-
-  [% endif %]%
-
-  [[ inf.__doc__ | rst_to_latex(top_heading_level=2) ]]
-
+  [%- if inf.prerequisite -%]\textit{Prerequisite: [[ inf.prerequisite ]]} \\ [% endif %]
+  [%- if inf.item -%]\textit{Item: [[ inf.item ]]} \\ [% endif %]
+  [[- inf.__doc__ | rst_to_latex(top_heading_level=2) -]]
 [% endfor %]

--- a/dungeonsheets/forms/magic_items_template.tex
+++ b/dungeonsheets/forms/magic_items_template.tex
@@ -1,30 +1,25 @@
 \pdfbookmark[0]{Magic Items}{Magic Items}
 \section*{Magic Items}
-
 [% if use_dnd_decorations %]
   [% for mitem in character.magic_items %]
     \pdfbookmark[1]{[[ mitem.name ]]}{Magic Items - [[ mitem.name ]]}
-        \DndItemHeader{[[ mitem.name ]]}{[% if mitem.item_type %][[ mitem.item_type ]], [[ mitem.rarity.lower() ]][% else %][[ mitem.rarity ]] item[% endif %][% if mitem.requires_attunement %] (requires attunement)[% endif %]}
-        [% if mitem.needs_implementation %] %
-            \textbf{**Not included in stats on Character Sheet} %
-        [% endif %] %
-                    
-        [[ mitem.__doc__|rst_to_latex ]]
+        \DndItemHeader{[[ mitem.name ]]}{[%- if mitem.item_type -%][[ mitem.item_type ]], [[ mitem.rarity.lower() ]]
+                                         [%- else -%][[ mitem.rarity ]] item[%- endif -%]
+                                         [% if mitem.requires_attunement %] (requires attunement)[% endif %]}
+        [%- if mitem.needs_implementation %]
+            \textbf{**Not included in stats on Character Sheet} \\
+        [%- endif -%]
+        [[- mitem.__doc__|rst_to_latex -]]
     [% endfor %]
 [% else %]
     [% for mitem in character.magic_items %]
     \pdfbookmark[1]{[[ mitem.name ]]}{Magic Items - [[ mitem.name ]]}
     \subsection*{[[ mitem.name ]]}
-
-    \noindent
     \textbf{Requires Attunement:} [[ mitem.requires_attunement ]] \\
     \textbf{Rarity:} [[ mitem.rarity ]] \\
-
-    [% if mitem.needs_implementation %] %
-        \textbf{**Not included in stats on Character Sheet} %
-    [% endif %] %
-                
-    [[ mitem.__doc__|rst_to_latex ]]
-
+    [%- if mitem.needs_implementation %] %
+        \textbf{**Not included in stats on Character Sheet} \\
+    [%- endif -%] %
+    [[- mitem.__doc__|rst_to_latex -]]
     [% endfor %]
 [% endif %]

--- a/dungeonsheets/forms/preamble.tex
+++ b/dungeonsheets/forms/preamble.tex
@@ -12,6 +12,22 @@
 \usepackage{enumitem}
 \setlist{noitemsep}
 
+% No indentation after lists
+\usepackage{etoolbox}
+\makeatletter
+\newcommand*\@NoIndentAfter{%
+    \@ifnextchar\par{%
+        \def\par{%
+            \everypar{\setbox\z@\lastbox\everypar{}}%
+            \@restorepar%
+        }%
+    }{}%
+}
+\newrobustcmd*{\NoIndentAfterThis}{\@NoIndentAfter\par\par}
+\makeatother
+\AfterEndEnvironment{enumerate}{\NoIndentAfterThis}
+\AfterEndEnvironment{itemize}{\NoIndentAfterThis}
+
 \newlength{\zerosep}
 [% if use_dnd_decorations %]
   \usepackage[layout=true]{dnd}

--- a/dungeonsheets/forms/spellbook_template.tex
+++ b/dungeonsheets/forms/spellbook_template.tex
@@ -1,9 +1,8 @@
 \pdfbookmark[0]{Spells}{Spells}
 \section*{Spells}
-
-[% for spl in character.spells %]
+[%- for spl in character.spells %]
   \pdfbookmark[1]{[[ spl.name ]]}{Spells - [[ spl.name ]]}
-  [% if use_dnd_decorations %]  
+  [%- if use_dnd_decorations %]
   \DndSpellHeader
     {[[ spl.name ]]}
     {[% if spl.level > 0 %][[ ordinals[spl.level] ]]-level [[ spl.magic_school ]][% else %][[ spl.magic_school ]] Cantrip[% endif %] [% if spl.ritual %](\textit{ritual})[% endif %]}
@@ -11,31 +10,28 @@
     {[[ spl.casting_range ]]}
     {[[ spl.component_string ]]}
     {[[ spl.duration ]]}
-  [% else %]
+  [%- else %]
   \section*{[[ spl.name ]]}
-    [% if spl.level > 0 %] %
-      \textit{[[ spl.magic_school ]] Level [[ spl.level ]]} %
-    [% else %] %
-      \textit{[[ spl.magic_school ]] Cantrip} %
-    [% endif %] %
-    [% if spl.ritual and spl.concentration %]%
-      (\textit{ritual}, \textit{concentration})%
-    [% elif spl.ritual %]%
-      (\textit{ritual})%
-    [% elif spl.concentration %]%
-      (\textit{concentration})%
-    [% endif %]%                     
-    %% \noindent
+    [%- if spl.level > 0 %]
+      \textit{[[ spl.magic_school ]] Level [[ spl.level ]]}
+    [%- else %]
+      \textit{[[ spl.magic_school ]] Cantrip}
+    [%- endif -%]
+    [%- if spl.ritual and spl.concentration %]
+      (\textit{ritual}, \textit{concentration})
+    [%- elif spl.ritual %]
+      (\textit{ritual})
+    [%- elif spl.concentration %]
+      (\textit{concentration})
+    [%- endif %]
     \begin{description}
-      \setlength{\itemsep}{\zerosep}%
-      \setlength{\parskip}{0pt}%
+      \setlength{\itemsep}{\zerosep}
+      \setlength{\parskip}{0pt}
       \item [Casting Time:] [[ spl.casting_time ]] \\
       \item [Duration:] [[ spl.duration ]] \\
       \item [Range:] [[ spl.casting_range ]] \\
       \item [Components:] [[ spl.component_string ]]
     \end{description}
-    % \vspace{\zerosep}
-  [% endif %]
-  [[ spl.__doc__ | rst_to_latex(top_heading_level=1) ]]
-
+  [%- endif -%]
+  [[- spl.__doc__ | rst_to_latex(top_heading_level=1) -]]
 [% endfor %]

--- a/dungeonsheets/forms/subclasses_template.tex
+++ b/dungeonsheets/forms/subclasses_template.tex
@@ -1,19 +1,16 @@
+
 \pdfbookmark[0]{Subclasses}{Subclasses}
 \section*{Subclasses}
 [% if use_dnd_decorations %]
-  [% for sc in character.subclasses if sc not in ['', None, 'None', 'none']%]
+  [%- for sc in character.subclasses if sc not in ['', None, 'None', 'none'] %]
     \pdfbookmark[1]{[[ sc.name ]]}{Subclasses - [[ sc.name ]]}
     \DndFeatHeader{[[ sc.name ]]} % Would like to add source here
-
-    [[ sc.__doc__ | rst_to_latex(top_heading_level=2) ]]
-
-    [% endfor %]
+    [[- sc.__doc__ | rst_to_latex(top_heading_level=2) ]]
+    [%- endfor %]
 [% else %]
-    [% for sc in character.subclasses if sc not in ['', None, 'None', 'none']%]
+    [%- for sc in character.subclasses if sc not in ['', None, 'None', 'none'] %]
     \pdfbookmark[1]{[[ sc.name ]]}{Subclasses - [[ sc.name ]]}
     \subsection*{[[ sc.name ]]}
-
-    [[ sc.__doc__ | rst_to_latex(top_heading_level=2) ]]
-
-    [% endfor %] 
+    [[- sc.__doc__ | rst_to_latex(top_heading_level=2) ]]
+    [%- endfor %]
 [% endif %]


### PR DESCRIPTION
Latex output contains a lot of whitespace and comments. These patches cater for cleaner latex output, and in so doing remove spurious newlines and indents here and there, and they remove indentation after lists (the latter thing could also be done otherwise, as noted in the commit message of that patch). I suspect that these patches also improve pdfbookmark placement.