### PR TITLE
Featurestats

### DIFF
--- a/dungeonsheets/character.py
+++ b/dungeonsheets/character.py
@@ -570,8 +570,6 @@ class Character(Creature):
             spells |= set(f.spells_known) | set(f.spells_prepared)
         for c in self.spellcasting_classes:
             spells |= set(c.spells_known) | set(c.spells_prepared)
-        if self.race is not None:
-            spells |= set(self.race.spells_known) | set(self.race.spells_prepared)
         return sorted(tuple(spells), key=(lambda x: x.name))
 
     @property
@@ -581,8 +579,6 @@ class Character(Creature):
             spells |= set(f.spells_prepared)
         for c in self.spellcasting_classes:
             spells |= set(c.spells_prepared)
-        if self.race is not None:
-            spells |= set(self.race.spells_prepared)
         return sorted(tuple(spells), key=(lambda x: x.name))
 
     def set_attrs(self, **attrs):

--- a/dungeonsheets/classes/ranger.py
+++ b/dungeonsheets/classes/ranger.py
@@ -71,7 +71,7 @@ class GloomStalker(SubClass):
     features_by_level[3] = [
         features.DreadAmbusher,
         features.UmbralSight,
-        features.Darkvision,
+        features.DarkvisionClass,
     ]
     features_by_level[7] = [features.IronMind]
     features_by_level[11] = [features.StalkersFlurry]

--- a/dungeonsheets/classes/sorcerer.py
+++ b/dungeonsheets/classes/sorcerer.py
@@ -91,7 +91,7 @@ class ShadowMagic(SubClass):
     features_by_level = defaultdict(list)
     features_by_level[1] = [
         features.EyesOfTheDark,
-        features.SuperiorDarkvision,
+        features.SuperiorDarkvisionClass,
         features.StrengthOfTheGrave,
     ]
     features_by_level[6] = [features.HoundOfIllOmen]

--- a/dungeonsheets/features/races.py
+++ b/dungeonsheets/features/races.py
@@ -288,6 +288,7 @@ class NaturalIllusionist(Feature):
 
     name = "Natural Illusionist"
     source = "Race (Forest Gnome)"
+    spells_known = spells_prepared = (spells.MinorIllusion,)
 
 
 class SpeakWithSmallBeasts(Feature):
@@ -435,6 +436,7 @@ class LightBearer(Feature):
 
     name = "Light Bearer"
     source = "Race (Aasimar)"
+    spells_known = spells_prepared = (spells.Light,)
 
 
 class AasimarRadiantSoul(Feature):

--- a/dungeonsheets/features/races.py
+++ b/dungeonsheets/features/races.py
@@ -146,10 +146,21 @@ class DrowMagic(Feature):
     ability for these spells.
 
     """
+    _spells = {1: [spells.DancingLights,], 3: [spells.FaerieFire,], 5: [spells.Darkness,]}
+    spells_known = []
+    spells_prepared = []
+
+    def __init__(self, owner):
+        if owner is not None:
+            level = owner.level
+            for lvl, spl in self._spells.items():
+                if level >= lvl:
+                    self.spells_known.extend(spl)
+                    self.spells_prepared.extend(spl)
+        super().__init__(owner=owner)
 
     name = "Drow Magic"
     source = "Race (Dark Elf)"
-    spells_known = spells_prepared = (spells.DancingLights,)
 
 
 # Halflings
@@ -373,16 +384,28 @@ class HellishResistance(Feature):
 
 
 class InfernalLegacy(Feature):
-    """You know the thaumaturgy cantrip.  Once you reach 3rd level, you can cast
+    """You know the thaumaturgy cantrip. Once you reach 3rd level, you can cast
     the hellish rebuke spell once per day as a 2nd-level spell. Once you reach
     5th level, you can also cast the darkness spell once per day. Charisma is
     your spellcasting ability for these spells.
 
     """
 
+    _spells = {1: [spells.Thaumaturgy,], 3: [spells.HellishRebuke,]}
+    spells_known = []
+    spells_prepared = []
+
+    def __init__(self, owner):
+        if owner is not None:
+            level = owner.level
+            for lvl, spl in self._spells.items():
+                if level >= lvl:
+                    self.spells_known.extend(spl)
+                    self.spells_prepared.extend(spl)
+        super().__init__(owner=owner)
+
     name = "Infernal Legacy"
     source = "Race (Tiefling)"
-    spells_known = spells_prepared = (spells.Thaumaturgy,)
 
 
 # Aasimar
@@ -492,6 +515,7 @@ class FirbolgMagic(Feature):
 
     name = "Firbolg Magic"
     source = "Race (Firbolg)"
+    spells_known = spells_prepared = (spells.DetectMagic, spells.DisguiseSelf,)
 
 
 class HiddenStep(Feature):
@@ -647,6 +671,18 @@ class ControlAirAndWater(Feature):
     rest. Charisma is your spellcasting ability for these spells.
 
     """
+    _spells = {1: [spells.FogCloud,], 3: [spells.GustOfWind,], 5: [spells.WallOfWater,]}
+    spells_known = []
+    spells_prepared = []
+
+    def __init__(self, owner):
+        if owner is not None:
+            level = owner.level
+            for lvl, spl in self._spells.items():
+                if level >= lvl:
+                    self.spells_known.extend(spl)
+                    self.spells_prepared.extend(spl)
+        super().__init__(owner=owner)
 
     name = "Control Air and Water"
     source = "Race (Triton)"
@@ -694,6 +730,7 @@ class MingleWithTheWind(Feature):
 
     name = "Mingle with the Wind"
     source = "Race (Air Genasi)"
+    spells_known = spells_prepared = (spells.Levitate,)
 
 
 class EarthWalk(Feature):
@@ -734,6 +771,18 @@ class ReachToTheBlaze(Feature):
     rest. Constitution is your spellcasting ability for these spells.
 
     """
+    _spells = {1: [spells.ProduceFlame,], 3: [spells.BurningHands,]}
+    spells_known = []
+    spells_prepared = []
+
+    def __init__(self, owner):
+        if owner is not None:
+            level = owner.level
+            for lvl, spl in self._spells.items():
+                if level >= lvl:
+                    self.spells_known.extend(spl)
+                    self.spells_prepared.extend(spl)
+        super().__init__(owner=owner)
 
     name = "Reach to the Blaze"
     source = "Race (Fire Genasi)"
@@ -757,14 +806,24 @@ class CallToTheWave(Feature):
     spells.
 
     """
+    _spells = {1: [spells.ShapeWater,], 3: [spells.CreateOrDestroyWater]}
+    spells_known = []
+    spells_prepared = []
+
+    def __init__(self, owner):
+        if owner is not None:
+            level = owner.level
+            for lvl, spl in self._spells.items():
+                if level >= lvl:
+                    self.spells_known.extend(spl)
+                    self.spells_prepared.extend(spl)
+        super().__init__(owner=owner)
 
     name = "Call to the Wave"
     source = "Race (Water Genasi)"
 
 
 # RFTLW Races
-
-
 class DualMind(Feature):
     """
     You have advantage on all Wisdom saving throws.
@@ -938,6 +997,18 @@ class InnateSpellcasting(Feature):
     your spellcasting ability for these spells.
 
     """
+    _spells = {1: [spells.PoisonSpray, spells.AnimalFriendship,], 3: [spells.Suggestion,]}
+    spells_known = []
+    spells_prepared = []
+
+    def __init__(self, owner):
+        if owner is not None:
+            level = owner.level
+            for lvl, spl in self._spells.items():
+                if level >= lvl:
+                    self.spells_known.extend(spl)
+                    self.spells_prepared.extend(spl)
+        super().__init__(owner=owner)
 
     name = "Innate Spellcasting"
     source = "Race (Yuan-Ti Pureblood)"

--- a/dungeonsheets/features/ranger.py
+++ b/dungeonsheets/features/ranger.py
@@ -483,6 +483,18 @@ class UmbralSight(Feature):
     source = "Ranger (Gloom Stalker)"
 
 
+class DarkvisionClass(Feature):
+    """Accustomed to life underground, you have superior vision in dark and dim
+    conditions. You can see in dim light within 60 feet of you as if it were
+    bright light, and in darkness as if it were dim light. You can't discern
+    color in darkness, only shades of gray.
+
+    """
+
+    name = "Darkvision (60')"
+    source = "Class (Gloom Stalker)"
+
+
 class IronMind(Feature):
     """By 7th level, you have honed your ability to resist the mind-altering
     powers of your prey. You gain proficiency in Wisdom saving throws. Ifyou

--- a/dungeonsheets/features/sorcerer.py
+++ b/dungeonsheets/features/sorcerer.py
@@ -426,6 +426,16 @@ class EyesOfTheDark(Feature):
     spells_known = (spells.Darkness,)
     spells_prepared = (spells.Darkness,)
 
+class SuperiorDarkvisionClass(Feature):
+    """Accustomed to life underground, you have superior vision in dark and dim
+    conditions. You can see in dim light within 120 feet of you as if it were
+    bright light, and in darkness as if it were dim light. You can't discern
+    color in darkness, only shades of gray.
+
+    """
+
+    name = "Darkvision (120')"
+    source = "Sorcerer (Shadow Magic)"
 
 class StrengthOfTheGrave(Feature):
     """Starting at 1st level, your existence in a twilight state between life

--- a/dungeonsheets/race.py
+++ b/dungeonsheets/race.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 
 from dungeonsheets import features as feats
-from dungeonsheets import spells, weapons
+from dungeonsheets import weapons
 from dungeonsheets.content_registry import default_content_registry
 
 
@@ -28,7 +28,6 @@ class Race:
     wisdom_bonus = 0
     charisma_bonus = 0
     hit_point_bonus = 0
-    spells_known = ()
 
     def __init__(self, owner=None):
         self.owner = owner
@@ -40,11 +39,6 @@ class Race:
             self.features_by_level[i] = [
                 f(owner=self.owner) for f in cls.features_by_level[i]
             ]
-        self.spells_known = [S() for S in cls.spells_known]
-
-    @property
-    def spells_prepared(self):
-        return self.spells_known
 
     def __str__(self):
         return self.name

--- a/dungeonsheets/race.py
+++ b/dungeonsheets/race.py
@@ -134,7 +134,6 @@ class DarkElf(_Elf):
         feats.SunlightSensitivity,
         feats.DrowMagic,
     )
-    spells_known = (spells.DancingLights,)
 
 
 Drow = DarkElf
@@ -416,7 +415,6 @@ class Triton(Race):
         feats.GuardiansOfTheDepths,
     )
     languages = ("Common", "Primordial")
-    spells_known = (spells.FogCloud,)
 
 
 # Aarakocra
@@ -564,7 +562,6 @@ class PureBlood(Race):
         feats.MagicResistance,
         feats.PoisonImmunity,
     )
-    spells_known = (spells.PoisonSpray,)
     languages = ("Common", "Abyssal", "Draconic")
 
 

--- a/dungeonsheets/race.py
+++ b/dungeonsheets/race.py
@@ -204,7 +204,6 @@ class ForestGnome(_Gnome):
     name = "Forest Gnome"
     dexterity_bonus = 1
     features = _Gnome.features + (feats.NaturalIllusionist, feats.SpeakWithSmallBeasts)
-    spells_known = (spells.MinorIllusion,)
 
 
 class RockGnome(_Gnome):
@@ -287,7 +286,6 @@ class _Aasimar(Race):
         feats.HealingHands,
         feats.LightBearer,
     )
-    spells_known = (spells.Light,)
 
 
 # Protector Aasimar

--- a/dungeonsheets/stats.py
+++ b/dungeonsheets/stats.py
@@ -8,6 +8,7 @@ from dungeonsheets.armor import HeavyArmor, NoArmor, NoShield
 from dungeonsheets.dice import dice_roll_mean
 from dungeonsheets.features import (
     AmbushMaster,
+    Alert,
     Defense,
     DraconicResilience,
     DreadAmbusher,
@@ -319,9 +320,13 @@ class NumericalInitiative:
             ini += actor.wisdom.modifier
         if actor.has_feature(RakishAudacity):
             ini += actor.charisma.modifier
+        if actor.has_feature(Alert):
+            ini += 5
         
         if actor.has_feature(JackOfAllTrades) and not added_proficiency:
             ini += actor.proficiency_bonus // 2
+        if actor.has_feature(RemarkableAthlete) and not added_proficiency:
+            ini += ceil(actor.proficiency_bonus / 2.0)
 
         has_advantage = (
             actor.has_feature(NaturalExplorerRevised)


### PR DESCRIPTION
This PR aims to clean up some code in feature application, adds more racial spells automatically, adds class-based darkvision, and adds some feat bonuses to initiative.

For review, I'd like to point out two things:
1. I removed all spell stuff from race.py
2. Some races include first level spells at second level, which I implemented as follows:

```python
+    class HellishRebukeAtLvl2(spells.HellishRebuke):
+        level = 2
+        __doc__ = spells.HellishRebuke.__doc__.replace('2nd', '3rd').replace('1st', '2nd')
+        name = "Hellish Rebuke (Racial Feature)"
+
+    _spells = {1: [spells.Thaumaturgy,], 3: [HellishRebukeAtLvl2,]}
+    spells_known = []
+    spells_prepared = []

```