### PR TITLE
MSavage latex template

### DIFF
--- a/dungeonsheets/character.py
+++ b/dungeonsheets/character.py
@@ -849,6 +849,7 @@ class Character(Creature):
     def proficiencies_by_type(self):
         prof_dict = {}
         w_pro = set(self.weapon_proficiencies)
+        w_pro.remove(weapons.Unarmed)
         if weapons.MartialWeapon in w_pro:
             prof_dict["Weapons"] = ["All Weapons"]
         elif weapons.SimpleWeapon in w_pro:

--- a/dungeonsheets/character.py
+++ b/dungeonsheets/character.py
@@ -850,16 +850,16 @@ class Character(Creature):
         prof_dict = {}
         w_pro = set(self.weapon_proficiencies)
         if weapons.MartialWeapon in w_pro:
-            prof_dict["Weapons"] = ["All weapons"]
+            prof_dict["Weapons"] = ["All Weapons"]
         elif weapons.SimpleWeapon in w_pro:
-            prof_dict["Weapons"] = ["Simple weapons"]
+            prof_dict["Weapons"] = ["Simple Weapons"]
             for w in w_pro:
                 if not (issubclass(w, weapons.SimpleWeapon)):
                     prof_dict["Weapons"] += [w.name]
         else:
             prof_dict["Weapons"] = [w.name for w in w_pro]
         if "Weapons" in prof_dict.keys():
-            prof_dict["Weapons"] = ", ".join(prof_dict["Weapons"]) + "."
+            prof_dict["Weapons"] = ", ".join(prof_dict["Weapons"])
         armor_types = ["all armor", "light armor", "medium armor", "heavy armor"]
         prof_set = set(
             [
@@ -867,13 +867,13 @@ class Character(Creature):
                 for prof in self.proficiencies_text.split(",")
             ]
         )
-        prof_dict["Armor"] = [ar for ar in armor_types if ar in prof_set]
-        if len(prof_dict["Armor"]) > 2 or "all armor" in prof_set:
-            prof_dict["Armor"] = ["All armor"]
-        if "shields" in prof_set:
-            prof_dict["Armor"] += ["shields"]
-        prof_dict["Armor"] = ", ".join(prof_dict["Armor"]) + "."
-        if hasattr(self, "chosen_tools"):
+        prof_dict["Armor"] = [ar.title() for ar in armor_types if ar in prof_set]
+        if len(prof_dict["Armor"]) > 2 or 'all armor' in prof_set:
+            prof_dict["Armor"] = ["All Armor"]
+        if 'shields' in prof_set:
+            prof_dict["Armor"] += ["Shields"]
+        prof_dict["Armor"] = ", ".join(prof_dict["Armor"])
+        if hasattr(self, 'chosen_tools'):
             prof_dict["Other"] = self.chosen_tools
         return prof_dict
 

--- a/dungeonsheets/character.py
+++ b/dungeonsheets/character.py
@@ -769,22 +769,22 @@ class Character(Creature):
     def features_summary(self):
         # save space for informed features and traits
         if hasattr(self, "features_and_traits"):
-            info_list = ["**Other Features**"]
-            info_list += [
-                text.strip()
-                for text in self.features_and_traits.split("\n")
-                if not (text.isspace())
-            ]
-            N = len(info_list)
-            for text in info_list:
-                if len(text) > 26:  # 26 is just a guess for expected size of lines
-                    N += 1
-            if N > 30:
-                return "\n".join(info_list[:30]) + "\n(...)"
-            N = 30 - N
-        else:
             info_list = []
             N = 30
+            if re.search(r'\S',  self.features_and_traits):
+                info_list = ["**Other Features**"]
+                info_list += [
+                    text.strip()
+                    for text in self.features_and_traits.split("\n")
+                    if not (text.isspace())
+                ]
+                N = len(info_list)
+                for text in info_list:
+                    if len(text) > 26:  # 26 is just a guess for expected size of lines
+                        N += 1
+                if N > 30:
+                    return "\n".join(info_list[:30]) + "\n(...)"
+                N = 30 - N
         if len(self.class_list) > 1:
             featS = ["**Multiclass**:"]
             for cl in self.class_list:

--- a/dungeonsheets/character.py
+++ b/dungeonsheets/character.py
@@ -829,16 +829,17 @@ class Character(Creature):
     @property
     def equipment_text(self):
         eq_list = []
-        if hasattr(self, "magic_items") and len(self.magic_items) > 0:
-            eq_list += ["**Magic Items**"]
-            eq_list += [item.name for item in self.magic_items]
         if hasattr(self, "equipment") and len(self.equipment.strip()) > 0:
-            eq_list += ["**Other Equipment**"]
             eq_list += [
                 text.strip()
                 for text in self.equipment.split("\n")
                 if not (text.isspace())
             ]
+        if hasattr(self, "magic_items") and len(self.magic_items) > 0:
+            sub_list = "**Magic Items:** "
+            for item in self.magic_items:
+                sub_list += item.name + ", "
+            eq_list += [sub_list[:-2]]
         cw, cc = self.carrying_weight, self.carrying_capacity
         eq_list += [f"**Weight:** {cw} lb\n\n**Capacity:** {cc} lb"]
 

--- a/dungeonsheets/character.py
+++ b/dungeonsheets/character.py
@@ -775,7 +775,7 @@ class Character(Creature):
                 info_list = ["**Other Features**"]
                 info_list += [
                     text.strip()
-                    for text in self.features_and_traits.split("\n")
+                    for text in self.features_and_traits.split("\n\n")
                     if not (text.isspace())
                 ]
                 N = len(info_list)
@@ -832,7 +832,7 @@ class Character(Creature):
         if hasattr(self, "equipment") and len(self.equipment.strip()) > 0:
             eq_list += [
                 text.strip()
-                for text in self.equipment.split("\n")
+                for text in self.equipment.split("\n\n")
                 if not (text.isspace())
             ]
         if hasattr(self, "magic_items") and len(self.magic_items) > 0:

--- a/dungeonsheets/forms/MSavage_template.tex
+++ b/dungeonsheets/forms/MSavage_template.tex
@@ -242,7 +242,7 @@
 
 [% if char.is_spellcaster %]
 % SPELLCASTING PAGE
-\renderspellsheet
+\spellsheetchoice
 [% endif %]
 
 \end{document}

--- a/dungeonsheets/forms/MSavage_template.tex
+++ b/dungeonsheets/forms/MSavage_template.tex
@@ -66,7 +66,7 @@
 \StealthSkillModifier{[[ "{:+d}".format(char.stealth.modifier) ]]}
 \SurvivalSkillModifier{[[ "{:+d}".format(char.survival.modifier) ]]}
 
-% Prociciencies
+% Proficiencies
 \StrengthProficiency{[[ "strength" in char.saving_throw_proficiencies ]]}
 \DexterityProficiency{[[ "dexterity" in char.saving_throw_proficiencies ]]}
 \ConstitutionProficiency{[[ "constitution" in char.saving_throw_proficiencies ]]}
@@ -123,9 +123,9 @@
 }
 
 \OtherProficienciesLanguages{
-\textbf{Languages:}  [[ char.languages ]] \\
+\textbf{Languages:}  [[ char.languages ]]. \\
 [%- for prof_type, values in char.proficiencies_by_type.items() %]
-\textbf{[[ prof_type ]]}: [[ values ]] \\
+\textbf{[[ prof_type ]]}: [[ values ]]. \\
 [%- endfor -%]
 }
 

--- a/dungeonsheets/forms/MSavage_template.tex
+++ b/dungeonsheets/forms/MSavage_template.tex
@@ -32,39 +32,39 @@
 \CharismaScore{[[ char.charisma.value ]]}
 
 % Ability modifiers
-\StrengthModifier{[[ "{:+d}".format(char.strength.modifier) ]]}
-\DexterityModifier{[[ "{:+d}".format(char.dexterity.modifier) ]]}
-\ConstitutionModifier{[[ "{:+d}".format(char.constitution.modifier) ]]}
-\IntelligenceModifier{[[ "{:+d}".format(char.intelligence.modifier) ]]}
-\WisdomModifier{[[ "{:+d}".format(char.wisdom.modifier) ]]}
-\CharismaModifier{[[ "{:+d}".format(char.charisma.modifier) ]]}
+\StrengthModifier{[[ char.strength.modifier ]]}
+\DexterityModifier{[[ char.dexterity.modifier ]]}
+\ConstitutionModifier{[[ char.constitution.modifier ]]}
+\IntelligenceModifier{[[ char.intelligence.modifier ]]}
+\WisdomModifier{[[ char.wisdom.modifier ]]}
+\CharismaModifier{[[ char.charisma.modifier ]]}
 
 % Saving Throws
-\StrengthSavingThrowModifier{[[ "{:+d}".format(char.strength.saving_throw) ]]}
-\DexteritySavingThrowModifier{[[ "{:+d}".format(char.dexterity.saving_throw) ]]}
-\ConstitutionSavingThrowModifier{[[ "{:+d}".format(char.constitution.saving_throw) ]]}
-\IntelligenceSavingThrowModifier{[[ "{:+d}".format(char.intelligence.saving_throw) ]]}
-\WisdomSavingThrowModifier{[[ "{:+d}".format(char.wisdom.saving_throw) ]]}
-\CharismaSavingThrowModifier{[[ "{:+d}".format(char.charisma.saving_throw) ]]}
+\StrengthSavingThrowModifier{[[ char.strength.saving_throw ]]}
+\DexteritySavingThrowModifier{[[ char.dexterity.saving_throw ]]}
+\ConstitutionSavingThrowModifier{[[ char.constitution.saving_throw ]]}
+\IntelligenceSavingThrowModifier{[[ char.intelligence.saving_throw ]]}
+\WisdomSavingThrowModifier{[[ char.wisdom.saving_throw ]]}
+\CharismaSavingThrowModifier{[[ char.charisma.saving_throw ]]}
 
-\AcrobaticsSkillModifier{[[ "{:+d}".format(char.acrobatics.modifier) ]]}
-\AnimalHandlingSkillModifier{[["{:+d}".format(char.animal_handling.modifier) ]]}
-\ArcanaSkillModifier{[[ "{:+d}".format(char.arcana.modifier) ]]}
-\AthleticsSkillModifier{[[ "{:+d}".format(char.athletics.modifier) ]]}
-\DeceptionSkillModifier{[[ "{:+d}".format(char.deception.modifier) ]]}
-\HistorySkillModifier{[[ "{:+d}".format(char.history.modifier) ]]}
-\InsightSkillModifier{[[ "{:+d}".format(char.insight.modifier) ]]}
-\IntimidationSkillModifier{[[ "{:+d}".format(char.intimidation.modifier) ]]}
-\InvestigationSkillModifier{[[ "{:+d}".format(char.investigation.modifier) ]]} 
-\MedicineSkillModifier{[[ "{:+d}".format(char.medicine.modifier) ]]}
-\NatureSkillModifier{[[ "{:+d}".format(char.nature.modifier) ]]}
-\PerceptionSkillModifier{[[ "{:+d}".format(char.perception.modifier) ]]} 
-\PerformanceSkillModifier{[[ "{:+d}".format(char.performance.modifier) ]]}
-\PersuasionSkillModifier{[[ "{:+d}".format(char.persuasion.modifier) ]]} 
-\ReligionSkillModifier{[[ "{:+d}".format(char.religion.modifier) ]]}
-\SleightOfHandSkillModifier{[[ "{:+d}".format(char.sleight_of_hand.modifier) ]]}
-\StealthSkillModifier{[[ "{:+d}".format(char.stealth.modifier) ]]}
-\SurvivalSkillModifier{[[ "{:+d}".format(char.survival.modifier) ]]}
+\AcrobaticsSkillModifier{[[ char.acrobatics.modifier ]]}
+\AnimalHandlingSkillModifier{[[ char.animal_handling.modifier ]]}
+\ArcanaSkillModifier{[[ char.arcana.modifier ]]}
+\AthleticsSkillModifier{[[ char.athletics.modifier ]]}
+\DeceptionSkillModifier{[[ char.deception.modifier ]]}
+\HistorySkillModifier{[[ char.history.modifier ]]}
+\InsightSkillModifier{[[ char.insight.modifier ]]}
+\IntimidationSkillModifier{[[ char.intimidation.modifier ]]}
+\InvestigationSkillModifier{[[ char.investigation.modifier ]]}
+\MedicineSkillModifier{[[ char.medicine.modifier ]]}
+\NatureSkillModifier{[[ char.nature.modifier ]]}
+\PerceptionSkillModifier{[[ char.perception.modifier ]]}
+\PerformanceSkillModifier{[[ char.performance.modifier ]]}
+\PersuasionSkillModifier{[[ char.persuasion.modifier ]]}
+\ReligionSkillModifier{[[ char.religion.modifier ]]}
+\SleightOfHandSkillModifier{[[ char.sleight_of_hand.modifier ]]}
+\StealthSkillModifier{[[ char.stealth.modifier ]]}
+\SurvivalSkillModifier{[[ char.survival.modifier ]]}
 
 % Proficiencies
 \StrengthProficiency{[[ "strength" in char.saving_throw_proficiencies ]]}
@@ -94,11 +94,11 @@
 \SurvivalProficiency{[[ "survival" in char.skill_proficiencies ]]}
 
 \Inspiration{[% if char.inspiration %] $\star$ [% endif %]}
-\Proficiency{[[ "{:+d}".format(char.proficiency_bonus) ]]}
+\Proficiency{[[ char.proficiency_bonus ]]}
 \Perception{[[ 10 + char.perception.modifier ]]} 
 
 \ArmorClass{[[ char.armor_class ]]}
-\Initiative{[[ char.initiative ]]}
+\Initiative{[[ char.initiative.replace("+", "") ]]}
 \Speed{[[ char.speed ]]}
 \MaxHitPoints{[[ char.hp_max ]]}
 [% if char.hp_current %]\CurrentHitPoints{[[ char.hp_current ]]}[% endif %]

--- a/dungeonsheets/forms/MSavage_template.tex
+++ b/dungeonsheets/forms/MSavage_template.tex
@@ -125,7 +125,9 @@
 \OtherProficienciesLanguages{
 \textbf{Languages:}  [[ char.languages ]]. \\
 [%- for prof_type, values in char.proficiencies_by_type.items() %]
+  [%- if not values == "": %]
 \textbf{[[ prof_type ]]}: [[ values ]]. \\
+  [%- endif -%]
 [%- endfor -%]
 }
 

--- a/dungeonsheets/forms/MSavage_template.tex
+++ b/dungeonsheets/forms/MSavage_template.tex
@@ -67,31 +67,31 @@
 \SurvivalSkillModifier{[[ char.survival.modifier ]]}
 
 % Proficiencies
-\StrengthProficiency{[[ "strength" in char.saving_throw_proficiencies ]]}
-\DexterityProficiency{[[ "dexterity" in char.saving_throw_proficiencies ]]}
-\ConstitutionProficiency{[[ "constitution" in char.saving_throw_proficiencies ]]}
-\IntelligenceProficiency{[[ "intelligence" in char.saving_throw_proficiencies ]]}
-\WisdomProficiency{[[ "wisdom" in char.saving_throw_proficiencies ]]}
-\CharismaProficiency{[[ "charisma" in char.saving_throw_proficiencies ]]}
+\SetStrengthProficiency{[% if "strength" in char.saving_throw_proficiencies %]1[% else %]0[% endif %]}
+\SetDexterityProficiency{[% if "dexterity" in char.saving_throw_proficiencies %]1[% else %]0[% endif %]}
+\SetConstitutionProficiency{[% if "constitution" in char.saving_throw_proficiencies %]1[% else %]0[% endif %]}
+\SetIntelligenceProficiency{[% if "intelligence" in char.saving_throw_proficiencies %]1[% else %]0[% endif %]}
+\SetWisdomProficiency{[% if "wisdom" in char.saving_throw_proficiencies %]1[% else %]0[% endif %]}
+\SetCharismaProficiency{[% if "charisma" in char.saving_throw_proficiencies %]1[% else %]0[% endif %]}
 
-\AcrobaticsProficiency{[[ "acrobatics" in char.skill_proficiencies ]]}
-\AnimalHandlingProficiency{[[ "animal handling" in char.skill_proficiencies ]]}
-\ArcanaProficiency{[[ "arcana" in char.skill_proficiencies ]]}
-\AthleticsProficiency{[[ "athletics" in char.skill_proficiencies ]]}
-\DeceptionProficiency{[[ "deception" in char.skill_proficiencies ]]}
-\HistoryProficiency{[[ "history" in char.skill_proficiencies ]]}
-\InsightProficiency{[[ "insight" in char.skill_proficiencies ]]}
-\IntimidationProficiency{[[ "intimidation" in char.skill_proficiencies ]]}
-\InvestigationProficiency{[[ "investigation" in char.skill_proficiencies ]]}
-\MedicineProficiency{[[ "medicine" in char.skill_proficiencies ]]}
-\NatureProficiency{[[ "nature" in char.skill_proficiencies ]]}
-\PerceptionProficiency{[[ "perception" in char.skill_proficiencies ]]}
-\PerformanceProficiency{[[ "performance" in char.skill_proficiencies ]]}
-\PersuasionProficiency{[[ "persuasion" in char.skill_proficiencies ]]}
-\ReligionProficiency{[[ "religion" in char.skill_proficiencies ]]}
-\SleightOfHandProficiency{[[ "sleight of hand" in char.skill_proficiencies ]]}
-\StealthProficiency{[[ "stealth" in char.skill_proficiencies ]]}
-\SurvivalProficiency{[[ "survival" in char.skill_proficiencies ]]}
+\SetAcrobaticsProficiency{[% if "acrobatics" in char.skill_proficiencies %]1[% else %]0[% endif %]}
+\SetAnimalHandlingProficiency{[% if "animal handling" in char.skill_proficiencies %]1[% else %]0[% endif %]}
+\SetArcanaProficiency{[% if "arcana" in char.skill_proficiencies %]1[% else %]0[% endif %]}
+\SetAthleticsProficiency{[% if "athletics" in char.skill_proficiencies %]1[% else %]0[% endif %]}
+\SetDeceptionProficiency{[% if "deception" in char.skill_proficiencies %]1[% else %]0[% endif %]}
+\SetHistoryProficiency{[% if "history" in char.skill_proficiencies %]1[% else %]0[% endif %]}
+\SetInsightProficiency{[% if "insight" in char.skill_proficiencies %]1[% else %]0[% endif %]}
+\SetIntimidationProficiency{[% if "intimidation" in char.skill_proficiencies %]1[% else %]0[% endif %]}
+\SetInvestigationProficiency{[% if "investigation" in char.skill_proficiencies %]1[% else %]0[% endif %]}
+\SetMedicineProficiency{[% if "medicine" in char.skill_proficiencies %]1[% else %]0[% endif %]}
+\SetNatureProficiency{[% if "nature" in char.skill_proficiencies %]1[% else %]0[% endif %]}
+\SetPerceptionProficiency{[% if "perception" in char.skill_proficiencies %]1[% else %]0[% endif %]}
+\SetPerformanceProficiency{[% if "performance" in char.skill_proficiencies %]1[% else %]0[% endif %]}
+\SetPersuasionProficiency{[% if "persuasion" in char.skill_proficiencies %]1[% else %]0[% endif %]}
+\SetReligionProficiency{[% if "religion" in char.skill_proficiencies %]1[% else %]0[% endif %]}
+\SetSleightOfHandProficiency{[% if "sleight of hand" in char.skill_proficiencies %]1[% else %]0[% endif %]}
+\SetStealthProficiency{[% if "stealth" in char.skill_proficiencies %]1[% else %]0[% endif %]}
+\SetSurvivalProficiency{[% if "survival" in char.skill_proficiencies %]1[% else %]0[% endif %]}
 
 \Inspiration{[% if char.inspiration %] $\star$ [% endif %]}
 \Proficiency{[[ char.proficiency_bonus ]]}

--- a/dungeonsheets/forms/MSavage_template.tex
+++ b/dungeonsheets/forms/MSavage_template.tex
@@ -74,24 +74,82 @@
 \SetWisdomProficiency{[% if "wisdom" in char.saving_throw_proficiencies %]1[% else %]0[% endif %]}
 \SetCharismaProficiency{[% if "charisma" in char.saving_throw_proficiencies %]1[% else %]0[% endif %]}
 
-\SetAcrobaticsProficiency{[% if "acrobatics" in char.skill_proficiencies %]1[% else %]0[% endif %]}
-\SetAnimalHandlingProficiency{[% if "animal handling" in char.skill_proficiencies %]1[% else %]0[% endif %]}
-\SetArcanaProficiency{[% if "arcana" in char.skill_proficiencies %]1[% else %]0[% endif %]}
-\SetAthleticsProficiency{[% if "athletics" in char.skill_proficiencies %]1[% else %]0[% endif %]}
-\SetDeceptionProficiency{[% if "deception" in char.skill_proficiencies %]1[% else %]0[% endif %]}
-\SetHistoryProficiency{[% if "history" in char.skill_proficiencies %]1[% else %]0[% endif %]}
-\SetInsightProficiency{[% if "insight" in char.skill_proficiencies %]1[% else %]0[% endif %]}
-\SetIntimidationProficiency{[% if "intimidation" in char.skill_proficiencies %]1[% else %]0[% endif %]}
-\SetInvestigationProficiency{[% if "investigation" in char.skill_proficiencies %]1[% else %]0[% endif %]}
-\SetMedicineProficiency{[% if "medicine" in char.skill_proficiencies %]1[% else %]0[% endif %]}
-\SetNatureProficiency{[% if "nature" in char.skill_proficiencies %]1[% else %]0[% endif %]}
-\SetPerceptionProficiency{[% if "perception" in char.skill_proficiencies %]1[% else %]0[% endif %]}
-\SetPerformanceProficiency{[% if "performance" in char.skill_proficiencies %]1[% else %]0[% endif %]}
-\SetPersuasionProficiency{[% if "persuasion" in char.skill_proficiencies %]1[% else %]0[% endif %]}
-\SetReligionProficiency{[% if "religion" in char.skill_proficiencies %]1[% else %]0[% endif %]}
-\SetSleightOfHandProficiency{[% if "sleight of hand" in char.skill_proficiencies %]1[% else %]0[% endif %]}
-\SetStealthProficiency{[% if "stealth" in char.skill_proficiencies %]1[% else %]0[% endif %]}
-\SetSurvivalProficiency{[% if "survival" in char.skill_proficiencies %]1[% else %]0[% endif %]}
+\SetAcrobaticsProficiency{[%- if char.acrobatics.is_expertise -%]2
+                          [%- elif char.acrobatics.is_proficient -%]1
+                          [%- elif char.acrobatics.is_jack_of_all_trades -%]0.5
+                          [%- elif char.acrobatics.is_remarkable_athlete -%]0.5
+                          [% else %]0[% endif %]}
+\SetAnimalHandlingProficiency{[%- if char.animal_handling.is_expertise -%]2
+                              [%- elif char.animal_handling.is_proficient -%]1
+                              [%- elif char.animal_handling.is_jack_of_all_trades -%]0.5
+                              [% else %]0[% endif %]}
+\SetArcanaProficiency{[%- if char.arcana.is_expertise -%]2
+                      [%- elif char.arcana.is_proficient -%]1
+                      [%- elif char.arcana.is_jack_of_all_trades -%]0.5
+                      [% else %]0[% endif %]}
+\SetAthleticsProficiency{[%- if char.athletics.is_expertise -%]2
+                         [%- elif char.athletics.is_proficient -%]1
+                         [%- elif char.athletics.is_jack_of_all_trades -%]0.5
+                         [%- elif char.athletics.is_remarkable_athlete -%]0.5
+                         [% else %]0[% endif %]}
+\SetDeceptionProficiency{[%- if char.deception.is_expertise -%]2
+                         [%- elif char.deception.is_proficient -%]1
+                         [%- elif char.deception.is_jack_of_all_trades -%]0.5
+                         [% else %]0[% endif %]}
+\SetHistoryProficiency{[%- if char.history.is_expertise -%]2
+                       [%- elif char.history.is_proficient -%]1
+                       [%- elif char.history.is_jack_of_all_trades -%]0.5
+                       [% else %]0[% endif %]}
+\SetInsightProficiency{[%- if char.insight.is_expertise -%]2
+                       [%- elif char.insight.is_proficient -%]1
+                       [%- elif char.insight.is_jack_of_all_trades -%]0.5
+                       [% else %]0[% endif %]}
+\SetIntimidationProficiency{[%- if char.intimidation.is_expertise -%]2
+                            [%- elif char.intimidation.is_proficient -%]1
+                            [%- elif char.intimidation.is_jack_of_all_trades -%]0.5
+                            [%- else %]0[% endif %]}
+\SetInvestigationProficiency{[%- if char.investigation.is_expertise -%]2
+                             [%- elif char.investigation.is_proficient -%]1
+                             [%- elif char.investigation.is_jack_of_all_trades -%]0.5
+                             [% else %]0[% endif %]}
+\SetMedicineProficiency{[%- if char.medicine.is_expertise -%]
+                        [%- elif char.medicine.is_proficient -%]1
+                        [%- elif char.medicine.is_jack_of_all_trades -%]0.5
+                        [% else %]0[% endif %]}
+\SetNatureProficiency{[%- if char.nature.is_expertise -%]2
+                      [%- elif char.nature.is_proficient -%]1
+                      [%- elif char.nature.is_jack_of_all_trades -%]0.5
+                      [% else %]0[% endif %]}
+\SetPerceptionProficiency{[%- if char.perception.is_expertise -%]2
+                          [%- elif char.perception.is_proficient -%]1
+                          [%-elif char.perception.is_jack_of_all_trades -%]0.5
+                          [% else %]0[% endif %]}
+\SetPerformanceProficiency{[%- if char.performance.is_expertise -%]2
+                           [%- elif char.performance.is_proficient -%]1
+                           [%- elif char.performance.is_jack_of_all_trades -%]0.5
+                           [% else %]0[% endif %]}
+\SetPersuasionProficiency{[%- if char.persuasion.is_expertise -%]2
+                          [%- elif char.persuasion.is_proficient -%]1
+                          [%- elif char.persuasion.is_jack_of_all_trades -%]0.5
+                          [% else %]0[% endif %]}
+\SetReligionProficiency{[%- if char.religion.is_expertise -%]2
+                        [%- elif char.religion.is_proficient -%]1
+                        [%- elif char.religion.is_jack_of_all_trades -%]0.5
+                        [% else %]0[% endif %]}
+\SetSleightOfHandProficiency{[%- if char.sleight_of_hand.is_expertise -%]2
+                             [%- elif char.sleight_of_hand.is_proficient -%]1
+                             [%- elif char.sleight_of_hand.is_jack_of_all_trades -%]0.5
+                             [%- elif char.sleight_of_hand.is_remarkable_athlete -%]0.5
+                             [% else %]0[% endif %]}
+\SetStealthProficiency{[%- if char.stealth.is_expertise -%]2
+                       [%- elif char.stealth.is_proficient -%]1
+                       [%- elif char.stealth.is_jack_of_all_trades -%]0.5
+                       [%- elif char.stealth.is_remarkable_athlete -%]0.5
+                       [% else %]0[% endif %]}
+\SetSurvivalProficiency{[%- if char.survival.is_expertise -%]2
+                        [%- elif char.survival.is_proficient -%]1
+                        [%- elif char.survival.is_jack_of_all_trades -%]0.5
+                        [% else %]0[% endif %]}
 
 \Inspiration{[% if char.inspiration %] $\star$ [% endif %]}
 \Proficiency{[[ char.proficiency_bonus ]]}

--- a/dungeonsheets/forms/MSavage_template.tex
+++ b/dungeonsheets/forms/MSavage_template.tex
@@ -116,14 +116,11 @@
 \AddWeapon{[[ w.name ]]}{[[ "{:+d}".format(w.attack_modifier) ]]}{[[ "{}/{}".format(w.damage, w.damage_type) ]]}
 [% endfor %]
 
-\AttacksAdditional{
-[% if char.armor %]\textbf{Armor}: [[ char.armor ]] \\ [% endif %]
-[% if char.shield %]\textbf{Shield}: [[ char.shield ]] \\ [% endif %]
-[[- char.attacks_and_spellcasting| boxed -]]
-}
+\AttacksAdditional{[%- if char.armor -%]\textbf{Armor}: [[ char.armor ]] \\ [%endif %]
+                   [%- if char.shield -%]\textbf{Shield}: [[ char.shield ]] \\ [%endif %]
+                   [[- char.attacks_and_spellcasting| boxed -]]}
 
-\OtherProficienciesLanguages{
-\textbf{Languages:}  [[ char.languages ]]. \\
+\OtherProficienciesLanguages{\textbf{Languages:} [[ char.languages ]]. \\
 [%- for prof_type, values in char.proficiencies_by_type.items() %]
   [%- if not values == "": %]
 \textbf{[[ prof_type ]]}: [[ values ]]. \\
@@ -133,25 +130,15 @@
 
 \Equipment{[[ char.equipment_text| boxed ]]}
 
-\PersonalityTraits{
-[[ char.personality_traits ]]
-}
+\PersonalityTraits{[[ char.personality_traits ]]}
 
-\Ideals{
-[[ char.ideals ]]
-}
+\Ideals{[[ char.ideals ]]}
 
-\Bonds{
-[[ char.bonds ]]
-}
+\Bonds{[[ char.bonds ]]}
 
-\Flaws{
-[[ char.flaws ]]
-}
+\Flaws{[[ char.flaws ]]}
 
-\FeaturesTraits{
-[[ char.features_summary| boxed ]]
-}
+\FeaturesTraits{[[ char.features_summary| boxed ]]}
 
 
 % Appearance
@@ -168,18 +155,14 @@
 \CharacterAppearance{[[ portrait ]]
 [[ char.appearance_text ]]
 }
-\AdditionalFeaturesAndTraits{
-[[ char.additional_description ]]
-}
-\Characterbackground{
-[[ char.backstory ]]
-}
-\Treasure{
-[[ char.treasure ]]
-}
-\AlliesAndOrganizations{
-[[ char.allies ]]
-}
+\AdditionalFeaturesAndTraits{[[ char.additional_description ]]}
+
+\Characterbackground{[[ char.backstory ]] }
+
+\Treasure{[[ char.treasure ]]}
+
+\AlliesAndOrganizations{[[ char.allies ]]}
+
 \OrganizationName{[[ char.org_name ]]}
 
 [% if char.is_spellcaster %]

--- a/dungeonsheets/forms/MSavage_template.tex
+++ b/dungeonsheets/forms/MSavage_template.tex
@@ -8,6 +8,7 @@
 \usepackage[UKenglish]{babel}
 
 \usepackage{dndtemplate}
+\usepackage{bookmark}
 
 \setlength\oddsidemargin{\dimexpr(\paperwidth-\textwidth)/2 - 1in\relax}
 \setlength\evensidemargin{\oddsidemargin}
@@ -235,13 +236,16 @@
 
 
 % CHARACTER PAGE
+\pdfbookmark[0]{Character Sheet}{Character Sheet}
 \rendercharactersheet
 
 % BACKSTORY PAGE
+\pdfbookmark[0]{Background Sheet}{Background Sheet}
 \renderbackgroundsheet
 
 [% if char.is_spellcaster %]
 % SPELLCASTING PAGE
+\pdfbookmark[0]{Spellcasting Sheet}{Spellcasting Sheet}
 \spellsheetchoice
 [% endif %]
 

--- a/dungeonsheets/latex.py
+++ b/dungeonsheets/latex.py
@@ -270,13 +270,30 @@ def msavage_spell_info(char):
                        'SeventhLevelSpell',
                        'EighthLevelSpell',
                        'NinthLevelSpell']
-    sheet_spaces = dict(zip(level_names,
+
+    fullcaster_sheet_spaces = dict(zip(level_names,
                     [8, 13, 13, 13, 13, 9, 9, 9, 7, 7]))
+    halfcaster_sheet_spaces = dict(zip(level_names,
+                    [11, 26, 19, 19, 19, 0, 0, 0, 0, 0]))
     comp_letters = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", 
-                  "L", "M"]
+                  "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", 
+                  "W", "X", "Y", "Z"]
+
     spellList = char.spell_casting_info["list"]
     for k, v in spellList.items():
-        slots_max = sheet_spaces[k]
+        # Determine which sheet to use (caster or half-caster).
+        # Prefer caster, unless we have no spells > 5th level and
+        # would overflow the caster sheet, then use half-caster.
+        fullcaster_slots_max = fullcaster_sheet_spaces[k]
+        halfcaster_slots_max = halfcaster_sheet_spaces[k]
+        only_low_level = all((char.spell_slots(level) == 0 for level in range(6, 10)))
+        if len(v) > fullcaster_slots_max and only_low_level:
+            slots_max=halfcaster_slots_max
+            tex4="\\newcommand{\spellsheetchoice}{\\renderhalfspellsheet}"
+        else:
+            slots_max=fullcaster_slots_max
+            tex4="\\newcommand{\spellsheetchoice}{\\renderspellsheet}"
+
         if len(v) > slots_max:
             vsel = sorted(v, key=lambda x: x[1], reverse=True)
         else:
@@ -290,4 +307,4 @@ def msavage_spell_info(char):
             slot_command_prep = slot_command+"Prepared"+"{"+str(spinfo[1])+"}"
             texT = texT + [slot_command_name, slot_command_prep]
     tex3 = "\n".join(texT) + '\n'
-    return "\n".join([tex1, tex2, tex3])
+    return "\n".join([tex1, tex2, tex3, tex4])


### PR DESCRIPTION
This PR contains patches that:

- Fix output that doesn't work with recent changes in the MSavage dndtemplate style
- Improve latex output for the MSavage latex template
- Use space on the MSavage latex template more efficiently
- Remove certain info if unused

I've compiled all examples with these patches.

These patches only touch code used for the MSavage latex template.