### PR TITLE
Several small fixes

### DIFF
--- a/dungeonsheets/character.py
+++ b/dungeonsheets/character.py
@@ -1156,7 +1156,7 @@ class Character(Creature):
 
         if filename.endswith(".pdf"):
             filename = filename.replace("pdf", "py")
-        make_sheet(filename, character=self, flatten=kwargs.get("flatten", True))
+        make_sheet(filename, flatten=kwargs.get("flatten", True))
 
 
 # Add backwards compatibility for tests

--- a/dungeonsheets/latex.py
+++ b/dungeonsheets/latex.py
@@ -280,20 +280,18 @@ def msavage_spell_info(char):
                   "W", "X", "Y", "Z"]
 
     spellList = char.spell_casting_info["list"]
+    # As default, assume fullcaster character and set spellsheet accordingly
+    tex4="\\newcommand{\spellsheetchoice}{\\renderspellsheet}"
     for k, v in spellList.items():
+        slots_max = fullcaster_sheet_spaces[k]
+        halfcaster_slots_max = halfcaster_sheet_spaces[k]
+        only_low_level = all((char.spell_slots(level) == 0 for level in range(6, 10)))
         # Determine which sheet to use (caster or half-caster).
         # Prefer caster, unless we have no spells > 5th level and
         # would overflow the caster sheet, then use half-caster.
-        fullcaster_slots_max = fullcaster_sheet_spaces[k]
-        halfcaster_slots_max = halfcaster_sheet_spaces[k]
-        only_low_level = all((char.spell_slots(level) == 0 for level in range(6, 10)))
-        if len(v) > fullcaster_slots_max and only_low_level:
+        if len(v) > slots_max and only_low_level:
             slots_max=halfcaster_slots_max
             tex4="\\newcommand{\spellsheetchoice}{\\renderhalfspellsheet}"
-        else:
-            slots_max=fullcaster_slots_max
-            tex4="\\newcommand{\spellsheetchoice}{\\renderspellsheet}"
-
         if len(v) > slots_max:
             vsel = sorted(v, key=lambda x: x[1], reverse=True)
         else:

--- a/dungeonsheets/make_sheets.py
+++ b/dungeonsheets/make_sheets.py
@@ -505,8 +505,25 @@ def msavage_sheet(character, basename, debug=False):
     """Another adaption. All changes can be easily included as options
     in the orignal functions, though."""
 
+    # Load portrait image file if present
+    portrait_command = ""
+    if character.portrait:
+        for image in character.images:
+            if re.search(r"" + character.portrait, str(image[0])):
+                character.images.remove(image)
+                break
+        portrait_command = r"\includegraphics[width=5.75cm]{" + character.portrait + "}"
+
+    # Move symbol image a bit left, if applicable
+    if character.symbol:
+        for image in character.images:
+            if re.search(r"" + character.symbol, str(image[0])):
+                character.images.remove(image)
+                character.images = [(character.symbol, 1, 488, 564, 145, 112)] + character.images
+                break
+
     tex = jinja_env.get_template("MSavage_template.tex").render(
-        char=character, portrait=""
+        char=character, portrait=portrait_command
     )
     latex.create_latex_pdf(
         tex,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "dungeosheets"
+name = "dungeonsheets"
 version = "0.19.0"
 authors = [
   {name="Mark Wolfman", email="mark@magicacid.com"},
@@ -46,6 +46,8 @@ dungeonsheets = [
   "modules/DND-5e-LaTeX-Template/lib/*",
   "modules/DND-5e-LaTeX-Template/img/*",
 ]
+
+[tool.setuptools_scm]
 
 # [project.urls]
 # "Homepage" = "https://github.com/pypa/sampleproject"


### PR DESCRIPTION
These are a couple of small fixes. Patches in this PR:
- Correct the positioning of portrait and symbol images in the MSavage latex template
- Fix a crash in create-character when create pdf is selected
- Fixes for the pyproject.toml file (spelling: dungeosheets --> dungeonsheets, and quieting a warning
- Implement the halfcaster spellsheet for the MSavage latex template; turns out that my original patch only worked on my main development branch, because, by chance, it sorted spells just so that the halfcaster sheet was selected for the character that I tested with. 

I've used all but the last patch for ages. I've tested this PR without any other patch on a couple of characters today.