### PR TITLE
More RPGtex dndtemplate options for the fancy feature pages

### DIFF
--- a/dungeonsheets/forms/companions_template.tex
+++ b/dungeonsheets/forms/companions_template.tex
@@ -35,7 +35,7 @@
           challenge = {[[ monster.challenge_rating ]] ([[ monster.challenge_rating | challenge_rating_to_xp ]] XP)},
         ]
         %\DndMonsterSection{Actions}
-        [[ monster.__doc__ | rst_to_latex(top_heading_level=2) ]]
+        [[ monster.__doc__ | monsterdoc ]]
     \end{DndMonster}
   [% endfor %]
   

--- a/dungeonsheets/forms/druid_shapes_template.tex
+++ b/dungeonsheets/forms/druid_shapes_template.tex
@@ -38,7 +38,7 @@
             challenge = {[[ shape.challenge_rating ]]},
           ]
         %\DndMonsterSection{Actions}
-        [[ shape.__doc__ | rst_to_latex(top_heading_level=2) ]]
+        [[ shape.__doc__ | monsterdoc ]]
     \end{DndMonster}
   [% endfor %]
   

--- a/dungeonsheets/forms/features_template.tex
+++ b/dungeonsheets/forms/features_template.tex
@@ -4,7 +4,7 @@
   [%- for feat in character.features %]
     \pdfbookmark[1]{[[ feat.name ]]}{Features - [[ feat.name ]]}
     \DndFeatHeader{[[ feat.name ]]}[Source: [[ feat.source ]]]
-    [[- feat.__doc__|rst_to_latex -]]
+    [[- feat.__doc__|rst_to_latex(use_dnd_decorations=use_dnd_decorations) -]]
   [%- endfor -%]
 [% else %]
   [%- for feat in character.features %]

--- a/dungeonsheets/forms/infusions_template.tex
+++ b/dungeonsheets/forms/infusions_template.tex
@@ -5,5 +5,5 @@
   \subsection*{[[ inf.name ]]}
   [%- if inf.prerequisite -%]\textit{Prerequisite: [[ inf.prerequisite ]]} \\ [% endif %]
   [%- if inf.item -%]\textit{Item: [[ inf.item ]]} \\ [% endif %]
-  [[- inf.__doc__ | rst_to_latex(top_heading_level=2) -]]
+  [[- inf.__doc__ | rst_to_latex(top_heading_level=2, use_dnd_decorations=use_dnd_decorations) -]]
 [% endfor %]

--- a/dungeonsheets/forms/magic_items_template.tex
+++ b/dungeonsheets/forms/magic_items_template.tex
@@ -9,7 +9,7 @@
         [%- if mitem.needs_implementation %]
             \textbf{**Not included in stats on Character Sheet} \\
         [%- endif -%]
-        [[- mitem.__doc__|rst_to_latex -]]
+        [[- mitem.__doc__|rst_to_latex(use_dnd_decorations=use_dnd_decorations) -]]
     [% endfor %]
 [% else %]
     [% for mitem in character.magic_items %]

--- a/dungeonsheets/forms/monsters_template.tex
+++ b/dungeonsheets/forms/monsters_template.tex
@@ -44,11 +44,9 @@
           languages = {[% if monster.languages %][[ monster.languages ]][% else %] --- [% endif %]},
           challenge = {[[ monster.challenge_rating ]] ([[ monster.challenge_rating | challenge_rating_to_xp ]] XP)},
         ]
-        %\DndMonsterSection{Actions}
-        [[ monster.__doc__ | rst_to_latex(top_heading_level=2) ]]
+        [[ monster.__doc__ | monsterdoc ]]
     \end{DndMonster}
   [% endfor %]
-  
 [% else %]
    \begin{tabular}{r | c c c c}
       Name & HP & Hit Dice & AC & Init. \\

--- a/dungeonsheets/forms/monsters_template.tex
+++ b/dungeonsheets/forms/monsters_template.tex
@@ -2,12 +2,15 @@
 \section*{Monsters}
 
 [% if use_dnd_decorations %]
-  \begin{DndTable}{r c c c c}
-   Name & HP & Hit Dice & AC & Init. \\
+  \begin{DndLongTable}[firsthead={\textbf{Name}
+                      & \textbf{HP}
+                      & \textbf{Hit Dice}
+                      & \textbf{AC}
+                      & \textbf{Init.} \\ }]{r c c c c}
    [% for monster in monsters|sort(attribute='name') %]
    [[ monster.name ]] & [[ monster.hp_max ]] & [[ monster.hit_dice ]] & [[ monster.armor_class ]] & [[ monster.initiative ]] \\
    [% endfor %]
-  \end{DndTable}
+  \end{DndLongTable}
 
   [% for monster in monsters|sort(attribute='name') %]
     \pdfbookmark[1]{[[ monster.name ]]}{Monsters - [[ monster.name ]]}

--- a/dungeonsheets/forms/party_summary_template.tex
+++ b/dungeonsheets/forms/party_summary_template.tex
@@ -11,8 +11,13 @@
 \section*{Party}
 
 [% if use_dnd_decorations %]
-  \begin{DndTable}{r c c c c c c c}
-    & Str & Dex & Con & Int & Wis & Cha \\
+  \begin{DndLongTable}[firsthead={
+                      & \textbf{Str}
+                      & \textbf{Dex}
+                      & \textbf{Con}
+                      & \textbf{Int}
+                      & \textbf{Wis}
+                      & \textbf{Cha} \\ }]{r c c c c c c c}
     [% for member in party %]
       [[ member.name[:18] ]]
       & [[ member.strength.modifier | mod_str ]]
@@ -23,9 +28,11 @@
       & [[ member.charisma.modifier | mod_str ]]
       \\
     [% endfor %]    
-  \end{DndTable}
-  \begin{DndTable}{r c c c}
-    & AC & Max HP & Spl.\ DC \\
+  \end{DndLongTable}
+  \begin{DndLongTable}[firsthead={
+                      & \textbf{AC}
+                      & \textbf{Max HP}
+                      & \textbf{Spl.\ DC} \\ }]{r c c c}
     [% for member in party %]
       [[ member.name[:28] ]]
       & [[ member.armor_class ]]
@@ -35,10 +42,12 @@
         [% endfor %]
       \\
     [% endfor %]
-  \end{DndTable}
+  \end{DndLongTable}
   % Passive stats
-  \begin{DndTable}{r c c c}
-    & Pas. Per.\ & Pas. Ins.\ & Pas. Inv.\ \\
+  \begin{DndLongTable}[firsthead={
+                      & \textbf{Pas. Per.\ }
+                      & \textbf{Pas. Ins.\ }
+                      & \textbf{Pas. Inv.\ } \\ }]{r c c c}
     [% for member in party %]
       [[ member.name[:28] ]]
       & [[ member.passive_perception ]] % Passive perception
@@ -46,15 +55,19 @@
       & [[ member.passive_investigation ]] % Passive investigation
       \\
     [% endfor %]
-  \end{DndTable}
+  \end{DndLongTable}
   %% XP thresholds for the party
-  \begin{DndTable}{r c c c c}
-    & Easy & Medium & Hard & Deadly \\
+  \begin{DndLongTable}[firsthead={
+                      & \textbf{Easy}
+                      & \textbf{Medium}
+                      & \textbf{Hard}
+                      & \textbf{Deadly} \\ }]{r c c c c}
     \textbf{XP Threshold} & 
     [% for threshold in party | xp_thresholds %]
         [[ "{:,}".format(threshold) ]] [% if not loop.last %]&[% endif %]
     [% endfor %]
-  \end{DndTable}
+      \\
+  \end{DndLongTable}
 [% else %]
   \begin{tabular}{r | c c c c c c}
     & Str & Dex & Con & Int & Wis & Cha \\

--- a/dungeonsheets/forms/party_summary_template.tex
+++ b/dungeonsheets/forms/party_summary_template.tex
@@ -2,7 +2,7 @@
   \pdfbookmark[1]{Summary}{Summary}
   \section*{Summary}
 
-  [[ summary | rst_to_latex ]]
+  [[ summary | rst_to_latex(use_dnd_decorations=use_dnd_decorations) ]]
 
 [% endif %]
 

--- a/dungeonsheets/forms/preamble.tex
+++ b/dungeonsheets/forms/preamble.tex
@@ -6,6 +6,7 @@
 \usepackage{alltt}
 \usepackage[bookmarks=true,bookmarksopen=true]{hyperref}
 \usepackage{bookmark}
+\usepackage{needspace}
 \usepackage{supertabular}
 
 % Make lists more compact
@@ -32,6 +33,59 @@
 [% if use_dnd_decorations %]
   \usepackage[layout=true]{dnd}
   \setlength{\zerosep}{0em}
+
+  [% raw %]
+  % dndlongtable environment
+  \ExplSyntaxOn
+
+  % Table options
+  \keys_define:nn { dnd / longtable }
+    {
+      color .tl_set:N            = \l__dnd_table_color_tl,
+      color .initial:n           = tablecolor,
+      color .value_required:n    = true,
+      header .tl_set:N           = \l__dnd_table_header_tl,
+      header .value_required:n   = true,
+      width .dim_set:N           = \l__dnd_table_width_dim,
+      width .value_required:n    = true,
+      firsthead .tl_set:N        = \l__table_firsthead_tl,
+      firsthead .value_required:n   = true,
+    }
+
+  \NewDocumentEnvironment {DndLongTable} { o m }
+  {
+    \group_begin:
+
+    \tablefirsthead{\l__table_firsthead_tl}
+
+    \dim_set:Nn \l__dnd_table_width_dim { \linewidth }
+    \tl_if_novalue:nF {#1}
+      { \keys_set:nn { dnd / longtable } {#1} }
+
+    \par \vspace { 9pt plus 3pt minus 3pt}
+
+    \tl_if_empty:NF \l__dnd_table_header_tl
+      {
+        \group_begin:
+          \needspace{5\baselineskip}
+          \noindent \DndFontTableTitle{ \l__dnd_table_header_tl}
+          \par \vspace{ 5pt plus 2pt minus 2pt }
+        \group_end:
+      }
+
+    \DndFontTableBody
+
+    \rowcolors {1} {} {\l__dnd_table_color_tl}
+
+    \begin{supertabular*} {\l__dnd_table_width_dim} {#2}
+  }
+  {
+    \end{supertabular*} \vspace { 9pt plus 3pt minus 3pt }
+    \group_end:
+  }
+  \ExplSyntaxOff
+  [% endraw %]
+
 [% else %]
   \usepackage[margin=1.5cm]{geometry}
   \usepackage[dvipsnames]{color}

--- a/dungeonsheets/forms/spellbook_template.tex
+++ b/dungeonsheets/forms/spellbook_template.tex
@@ -33,5 +33,5 @@
       \item [Components:] [[ spl.component_string ]]
     \end{description}
   [%- endif -%]
-  [[- spl.__doc__ | rst_to_latex(top_heading_level=1) -]]
+  [[- spl.__doc__ | rst_to_latex(top_heading_level=1, use_dnd_decorations=use_dnd_decorations) -]]
 [% endfor %]

--- a/dungeonsheets/forms/subclasses_template.tex
+++ b/dungeonsheets/forms/subclasses_template.tex
@@ -5,7 +5,7 @@
   [%- for sc in character.subclasses if sc not in ['', None, 'None', 'none'] %]
     \pdfbookmark[1]{[[ sc.name ]]}{Subclasses - [[ sc.name ]]}
     \DndFeatHeader{[[ sc.name ]]} % Would like to add source here
-    [[- sc.__doc__ | rst_to_latex(top_heading_level=2) ]]
+    [[- sc.__doc__ | rst_to_latex(top_heading_level=2, use_dnd_decorations=use_dnd_decorations) ]]
     [%- endfor %]
 [% else %]
     [%- for sc in character.subclasses if sc not in ['', None, 'None', 'none'] %]

--- a/dungeonsheets/latex.py
+++ b/dungeonsheets/latex.py
@@ -196,7 +196,7 @@ def rst_to_latex(rst, top_heading_level: int=0, format_dice: bool = True, use_dn
     format_dice
       If true, dice strings (e.g. "1d4") will be formatted in
       monospace font.
-    
+
     Returns
     =======
     tex : str
@@ -214,10 +214,18 @@ def rst_to_latex(rst, top_heading_level: int=0, format_dice: bool = True, use_dn
         tex = tex_parts["body"]
     # Apply fancy D&D decorations
     if use_dnd_decorations:
-        tex = re.sub(r"p{[0-9.]+\\DUtablewidth}", "l ", tex, flags=re.M)
-        tex = tex.replace(r"\begin{supertabular}[c]", r"\begin{DndTable}")
-        tex = tex.replace(r"\begin{supertabular}", r"\begin{DndTable}")
-        tex = tex.replace(r"\end{supertabular}", r"\end{DndTable}")
+        tex = tex.replace(r"\begin{supertabular}[c]", r"\begin{DndLongTable}[header=]")
+        tex = tex.replace(r"\begin{supertabular}", r"\begin{DndLongTable}[header=]")
+        tex = tex.replace(r"\end{supertabular}", r"\end{DndLongTable}")
+
+        # Correct table header to the DndLongTable format.
+        # First deal with the table caption, if present:
+        tex = re.sub(r"(begin{DndLongTable}\[header=)\](.*?\n)\\multicolumn.*?\n(.*?)\n.*?\\\\\n",
+                     r"\1\3]\2", tex, flags=re.M|re.DOTALL)
+        # Next, take the first table row and define it as the first page table header:
+        tex = re.sub(r"(begin{DndLongTable}\[header=.*?)\](.*?)\n(.*?\\\\)\n\n",
+                     r"\1,firsthead={\3 }]\2\n", tex, flags=re.M|re.DOTALL)
+
     return tex
 
 def rst_to_boxlatex(rst):

--- a/dungeonsheets/make_sheets.py
+++ b/dungeonsheets/make_sheets.py
@@ -56,6 +56,7 @@ jinja_env.filters["rst_to_html"] = epub.rst_to_html
 jinja_env.filters["to_heading_id"] = epub.to_heading_id
 jinja_env.filters["boxed"] = latex.rst_to_boxlatex
 jinja_env.filters["spellsheetparser"] = latex.msavage_spell_info
+jinja_env.filters["monsterdoc"] = latex.RPGtex_monster_info
 
 # Custom types
 File = Union[Path, str]

--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -105,7 +105,7 @@ class MarkdownTestCase(unittest.TestCase):
         self.assertNotIn("endfirsthead", tex)
         # Check that fancy decorations uses the DndTable environment
         tex = latex.rst_to_latex(table_rst, use_dnd_decorations=True)
-        self.assertIn(r"\begin{DndTable}{l l l }", tex)
+        self.assertIn(r"\begin{DndLongTable}[header=,firsthead={\textbf{%", tex)
 
     def test_rst_all_spells(self):
         for spell in spells.all_spells():


### PR DESCRIPTION
This PR aims to make full use of all latex formatting options in the [RPGtex latex dnd style](https://github.com/rpgtex/DND-5e-LaTeX-Template). One patch switches the tables in the fancy pages over to the dndtable format. The other adds a jinja filter to format monsters completely according to the rpgtex monster format.

If needed, I can share two pdfs with "before" and "after" that showcase the changes.