### PR TITLE
Feature pages: Sort spells by level and name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,10 @@ Consider using the ``-F`` option to include the excellent D&D 5e
 template for rendering spellbooks, druid wild forms and features
 pages (https://github.com/rpgtex/DND-5e-LaTeX-Template).
 
+By default, your character's spells are ordered alphabetically. If you
+would like your spellbook to be ordered by level, you can use the ``-S``
+option to do so.
+
 If you'd like a **step-by-step walkthrough** for creating a new
 character, just run ``create-character`` from a command line and a
 helpful menu system will take care of the basics for you.

--- a/dungeonsheets/forms/spellbook_template.tex
+++ b/dungeonsheets/forms/spellbook_template.tex
@@ -1,6 +1,28 @@
 \pdfbookmark[0]{Spells}{Spells}
 \section*{Spells}
-[%- for spl in character.spells %]
+
+\pdfbookmark[1]{Spellcasting details}{Spells - Spellcasting details}
+\subsection*{Spellcasting details}
+\textbf{Spellcasting Class:}
+[%- for spell_class in character.spellcasting_classes -%]
+[% if not loop.first %] /[% endif %] [[ spell_class.name ]] [[ spell_class.level ]]
+[%- endfor %] \\
+\noindent\textbf{Spellcasting Abilitiy:}
+[%- for spell_class in character.spellcasting_classes -%]
+[%- if not loop.first %] /[% endif %] [[ spell_class.spellcasting_ability | stat_abbreviation ]]
+[%- endfor %] \\
+\noindent\textbf{Spell Save DC:}
+[%- for spell_class in character.spellcasting_classes -%]
+[%- set spell_save_dc = character.spell_save_dc(spell_class) -%]
+[%- if not loop.first %] /[% endif %] [[ spell_save_dc ]]
+[%- endfor %] \\
+\noindent\textbf{Spell Attack Bonus:}
+[%- for spell_class in character.spellcasting_classes -%]
+[%- set spell_atk_bonus = character.spell_attack_bonus(spell_class) -%]
+[%- if not loop.first %] /[% endif %] [[ spell_atk_bonus | mod_str ]]
+[%- endfor %]
+
+[% for spl in character.spells %]
   \pdfbookmark[1]{[[ spl.name ]]}{Spells - [[ spl.name ]]}
   [%- if use_dnd_decorations %]
   \DndSpellHeader

--- a/dungeonsheets/forms/spellbook_template.tex
+++ b/dungeonsheets/forms/spellbook_template.tex
@@ -20,12 +20,27 @@
 [%- for spell_class in character.spellcasting_classes -%]
 [%- set spell_atk_bonus = character.spell_attack_bonus(spell_class) -%]
 [%- if not loop.first %] /[% endif %] [[ spell_atk_bonus | mod_str ]]
-[%- endfor %]
+[%- endfor -%]
 
+[% if spell_order %][% set headercounter_ns = namespace(counter = -1) %][% endif %]
 [% if spell_order %][% set spell_list = character.spells|sort(attribute='level') %][% else %][% set spell_list = character.spells %][% endif %]
 [% for spl in spell_list %]
-  \pdfbookmark[1]{[[ spl.name ]]}{Spells - [[ spl.name ]]}
-  [%- if use_dnd_decorations %]
+  [%- if spell_order %]
+    [%- if spl.level > headercounter_ns.counter %]
+       \pdfbookmark[1]{[%- if spl.level > 0 -%]
+                       [[ ordinals[spl.level] ]]-Level Spells
+                       [%- else %]Cantrips[% endif %]}{Spells - [%- if spl.level > 0 -%]
+                                                                [[ ' ' + ordinals[spl.level] ]]-Level Spells
+                                                                [%- else %] Cantrips[%- endif %]}
+       \subsection*{[% if spl.level > 0 %][[ ordinals[spl.level] ]]-Level Spells[% else %]Cantrips[% endif %]}
+       [%- set headercounter_ns.counter = spl.level -%]
+    [%- endif %]
+    \pdfbookmark[2]{[[ spl.name ]]}{Spells - [% if spl.level > 0 %][[ ordinals[spl.level] ]]-Level Spells[% else %]Cantrips[% endif %] - [[ spl.name ]]}
+  [% else %]
+    \pdfbookmark[1]{[[ spl.name ]]}{[% if spl.level > 0 %][[ ordinals[spl.level] ]]-Level Spells[% else %]Cantrips[% endif %] - [[ spl.name ]]}
+  [% endif %]
+
+  [%- if use_dnd_decorations -%]
   \DndSpellHeader
     {[[ spl.name ]]}
     {[% if spl.level > 0 %][[ ordinals[spl.level] ]]-level [[ spl.magic_school ]][% else %][[ spl.magic_school ]] Cantrip[% endif %] [% if spl.ritual %](\textit{ritual})[% endif %]}
@@ -33,8 +48,12 @@
     {[[ spl.casting_range ]]}
     {[[ spl.component_string ]]}
     {[[ spl.duration ]]}
-  [%- else %]
-  \section*{[[ spl.name ]]}
+  [%- else -%]
+    [%- if spell_order -%]
+      \subsubsection*{[[ spl.name ]]}
+    [%- else -%]
+      \section*{[[ spl.name ]]}
+    [%- endif -%]
     [%- if spl.level > 0 %]
       \textit{[[ spl.magic_school ]] Level [[ spl.level ]]}
     [%- else %]

--- a/dungeonsheets/forms/spellbook_template.tex
+++ b/dungeonsheets/forms/spellbook_template.tex
@@ -22,7 +22,8 @@
 [%- if not loop.first %] /[% endif %] [[ spell_atk_bonus | mod_str ]]
 [%- endfor %]
 
-[% for spl in character.spells %]
+[% if spell_order %][% set spell_list = character.spells|sort(attribute='level') %][% else %][% set spell_list = character.spells %][% endif %]
+[% for spl in spell_list %]
   \pdfbookmark[1]{[[ spl.name ]]}{Spells - [[ spl.name ]]}
   [%- if use_dnd_decorations %]
   \DndSpellHeader

--- a/dungeonsheets/make_sheets.py
+++ b/dungeonsheets/make_sheets.py
@@ -71,6 +71,7 @@ class CharacterRenderer:
         character: Character,
         content_suffix: str = "tex",
         use_dnd_decorations: bool = False,
+        spell_order: bool = False
     ):
         template = jinja_env.get_template(
             self.template_name.format(suffix=content_suffix)
@@ -78,6 +79,7 @@ class CharacterRenderer:
         return template.render(
             character=character,
             use_dnd_decorations=use_dnd_decorations,
+            spell_order=spell_order,
             ordinals=ORDINALS,
         )
 
@@ -160,6 +162,7 @@ def make_sheet(
     fancy_decorations: bool = False,
     debug: bool = False,
     use_tex_template: bool = False,
+    spell_order: bool = False,
 ):
     """Make a character or GM sheet into a PDF.
     Parameters
@@ -199,6 +202,7 @@ def make_sheet(
             fancy_decorations=fancy_decorations,
             debug=debug,
             use_tex_template=use_tex_template,
+            spell_order=spell_order,
         )
     return ret
 
@@ -388,6 +392,7 @@ def make_character_content(
     character: Character,
     content_format: str,
     fancy_decorations: bool = False,
+    spell_order: bool = False,
 ) -> List[str]:
     """Prepare the inner content for a character sheet.
 
@@ -465,6 +470,7 @@ def make_character_content(
                 character,
                 content_suffix=content_format,
                 use_dnd_decorations=fancy_decorations,
+                spell_order=spell_order,
             )
         )
     if len(getattr(character, "infusions", [])) > 0:
@@ -546,6 +552,7 @@ def make_character_sheet(
     fancy_decorations: bool = False,
     debug: bool = False,
     use_tex_template: bool = False,
+    spell_order: bool = False,
 ):
     """Prepare a PDF character sheet from the given character file.
 
@@ -585,6 +592,7 @@ def make_character_sheet(
         character=character,
         content_format=content_suffix,
         fancy_decorations=fancy_decorations,
+        spell_order=spell_order,
     )
     # Typeset combined LaTeX file
     if output_format == "pdf":
@@ -686,6 +694,7 @@ def _build(filename, args) -> int:
             debug=args.debug,
             fancy_decorations=args.fancy_decorations,
             use_tex_template=args.use_tex_template,
+            spell_order=args.spell_order,
         )
     except exceptions.CharacterFileFormatError:
         # Only raise the failed exception if this file is explicitly given
@@ -722,6 +731,14 @@ def main(args=None):
         "-r",
         action="store_true",
         help="Descend into subfolders looking for character files",
+    )
+    parser.add_argument(
+        "--spells-by-level",
+        "-S",
+        default=False,
+        action="store_true",
+        help="Order spells by level in the feature pages.",
+        dest="spell_order",
     )
     parser.add_argument(
         "--fancy-decorations",

--- a/tests/test_make_sheets.py
+++ b/tests/test_make_sheets.py
@@ -250,6 +250,13 @@ class TexCreatorTestCase(unittest.TestCase):
         self.assertIn(r"\section*{Spells}", tex)
         self.assertIn(r"\section*{Invisibility}", tex)
 
+    def test_create_spellbook_tex(self):
+        char = self.new_character()
+        tex = make_sheets.create_spellbook_content(character=char, content_suffix="tex", spell_order=True)
+        self.assertIn(r"\section*{Spells}", tex)
+        self.assertIn(r"\subsection*{2nd-Level Spells}", tex)
+        self.assertIn(r"\subsubsection*{Invisibility}", tex)
+
     def test_create_infusions_tex(self):
         char = self.new_character()
         tex = make_sheets.create_infusions_content(character=char, content_suffix="tex")


### PR DESCRIPTION
These four patches help optionally sorting spells by both level and name, instead of by name only. I'll admit that the first patch is slightly off-topic.

The first patch adds a short overview of a character's spellcasting details to the spellcasting section of the feature pages, see example:

![image](https://github.com/user-attachments/assets/4687db39-dc3f-4b3f-b106-6ea1f250bf2a)

The second patch adds an commandline option to sort spells by level and name:
`  --spells-by-level, -S            Order spells by level in the feature pages` and implements it.

The third patch implements headers and pdf bookmarks for each spell level in the feature pages.

The fourth patch adds documentation.

These patches work for both the regular and the fancy latex pages.