### PR TITLE
Latex template visual improvements

### DIFF
--- a/dungeonsheets/character.py
+++ b/dungeonsheets/character.py
@@ -929,7 +929,7 @@ class Character(Creature):
             prepared = s in self.spells_prepared
             level_info = level_names[s.level]
             info_there = spell_list.get(level_info, [])
-            spell_list[level_info] = info_there + [(s.name, prepared)]
+            spell_list[level_info] = info_there + [(re.sub(r"\$", r"\$", str(s)), prepared)]
         spell_info["list"] = spell_list
         return spell_info
 

--- a/dungeonsheets/character.py
+++ b/dungeonsheets/character.py
@@ -823,7 +823,7 @@ class Character(Creature):
         if self.shield:
             weight += 6
         weight += sum([self.cp, self.sp, self.ep, self.gp, self.pp]) / 50
-        return round(weight, 2)
+        return round(weight)
 
     @property
     def equipment_text(self):
@@ -839,10 +839,12 @@ class Character(Creature):
             for item in self.magic_items:
                 sub_list += item.name + ", "
             eq_list += [sub_list[:-2]]
-        cw, cc = self.carrying_weight, self.carrying_capacity
-        eq_list += [f"**Weight:** {cw} lb\n\n**Capacity:** {cc} lb"]
-
         return "\n\n".join(eq_list)
+
+    @property
+    def weight_and_capacity_text(self):
+        cw, cc = self.carrying_weight, self.carrying_capacity
+        return f"**Weight:** {cw} lb **Capacity:** {cc} lb"
 
     @property
     def proficiencies_by_type(self):

--- a/dungeonsheets/forms/MSavage_template.tex
+++ b/dungeonsheets/forms/MSavage_template.tex
@@ -187,7 +187,7 @@
 [%- endfor -%]
 }
 
-\Equipment{[[ char.equipment_text| boxed ]]}
+\Equipment{[[ char.equipment_text| boxed -]] \\ \footnotesize{[[ char.weight_and_capacity_text| boxed ]]}}
 
 \PersonalityTraits{[[ char.personality_traits ]]}
 

--- a/dungeonsheets/forms/MSavage_template.tex
+++ b/dungeonsheets/forms/MSavage_template.tex
@@ -16,8 +16,7 @@
 % Headline
 \CharacterName{[[ char.name ]]}
 
-% adds only main class and total level to prevent overflow
-\Class{[[ char.primary_class.name ]] [[ char.level ]]}
+\Class{[[ char.classes_and_levels ]]}
 \Background{[[ char.background ]]}
 \PlayerName{[[ char.player_name ]]}
 \Race{[[ char.race ]]}

--- a/dungeonsheets/forms/MSavage_template.tex
+++ b/dungeonsheets/forms/MSavage_template.tex
@@ -212,7 +212,7 @@
 % background
 
 \CharacterAppearance{[[ portrait ]]
-[[ char.appearance_text ]]
+[[- char.appearance_text -]]
 }
 \AdditionalFeaturesAndTraits{[[ char.additional_description ]]}
 

--- a/dungeonsheets/forms/MSavage_template.tex
+++ b/dungeonsheets/forms/MSavage_template.tex
@@ -223,12 +223,6 @@
 
 \OrganizationName{[[ char.org_name ]]}
 
-[% if char.is_spellcaster %]
-%Magic
-[[ char | spellsheetparser ]]
-[% endif %]
-
-
 \begin{document}
 \newgeometry{left=0cm,right=0cm,top=0cm,bottom=0cm}
 \onecolumn
@@ -242,10 +236,10 @@
 \pdfbookmark[0]{Background Sheet}{Background Sheet}
 \renderbackgroundsheet
 
-[% if char.is_spellcaster %]
+[% if char.is_spellcaster -%]
 % SPELLCASTING PAGE
 \pdfbookmark[0]{Spellcasting Sheet}{Spellcasting Sheet}
-\spellsheetchoice
-[% endif %]
+[[ char | spellsheetparser ]]
+[%- endif -%]
 
 \end{document}

--- a/dungeonsheets/latex.py
+++ b/dungeonsheets/latex.py
@@ -251,6 +251,7 @@ def rst_to_latex(rst, top_heading_level: int=0, format_dice: bool = True, use_dn
 
     return tex
 
+
 def rst_to_boxlatex(rst):
     """Adapted rst translation from dungeonsheets latex module, removing
     dice parsing and indentation."""
@@ -261,6 +262,7 @@ def rst_to_boxlatex(rst):
     tex = tex_parts["body"]
     tex = tex.replace('\n\n', ' \\\\\n')
     return tex
+
 
 def msavage_spell_info(char):
     """Generates the spellsheet for msavage template."""
@@ -310,33 +312,60 @@ def msavage_spell_info(char):
                   "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", 
                   "W", "X", "Y", "Z"]
 
+    # spellList is a dict.
+    # The keys in spellList are the level names, the values are lists of tuples:
+    # Each tuple consists of two elements: a spell name and a boolean for prepared.
+    # So: spellList = {levelname : [(spellname, preparedbool), ]}
     spellList = char.spell_casting_info["list"]
-    # As default, assume fullcaster character and set spellsheet accordingly
-    tex4="\\newcommand{\spellsheetchoice}{\\renderspellsheet}"
-    for k, v in spellList.items():
-        slots_max = fullcaster_sheet_spaces[k]
-        halfcaster_slots_max = halfcaster_sheet_spaces[k]
-        only_low_level = all((char.spell_slots(level) == 0 for level in range(6, 10)))
-        # Determine which sheet to use (caster or half-caster).
-        # Prefer caster, unless we have no spells > 5th level and
-        # would overflow the caster sheet, then use half-caster.
-        if len(v) > slots_max and only_low_level:
-            slots_max=halfcaster_slots_max
-            tex4="\\newcommand{\spellsheetchoice}{\\renderhalfspellsheet}"
-        if len(v) > slots_max:
-            vsel = sorted(v, key=lambda x: x[1], reverse=True)
-        else:
-            vsel = v[:]
-        for spinfo, slot in zip(vsel[:slots_max], comp_letters):
-            slot_command = "\\"+k+'Slot'+slot
-            slot_command_name = slot_command+"{"+spinfo[0]+"}"
-            if k == "Cantrip":
-                texT = texT + [slot_command_name]
-                continue
-            slot_command_prep = slot_command+"Prepared"+"{"+str(spinfo[1])+"}"
-            texT = texT + [slot_command_name, slot_command_prep]
-    tex3 = "\n".join(texT) + '\n'
-    return "\n".join([tex1, tex2, tex3, tex4])
+    # Default, assume fullcaster character and associated spellsheet.
+    fullcaster = True
+    # Determine which sheet to use (fullcaster or halfcaster).
+    # Only use halfcaster when we have no spells > 5th level and
+    # would overflow the fullcaster sheet.
+    # Keep the same sheet for overflow pages, if any.
+    only_low_level = all((char.spell_slots(level) == 0 for level in range(6, 10)))
+    if (any(len(spellList[key]) > fullcaster_sheet_spaces[key] for key in spellList.keys())
+            and only_low_level):
+        fullcaster = False
+
+    def AddSpellPage(fullcaster = True):
+        texT = []
+        for k, v in spellList.items():
+            spells_this_level_and_page = len(v)
+            if fullcaster:
+                spellsheet_command = "\\renderspellsheet"
+                slots_max = fullcaster_sheet_spaces[k]
+            else:
+                spellsheet_command = "\\renderhalfspellsheet"
+                slots_max = halfcaster_sheet_spaces[k]
+            for spinfo, slot in zip(v[:slots_max], comp_letters):
+                spellList[k].remove(spinfo)
+                slot_command = "\\"+k+'Slot'+slot
+                slot_command_name = slot_command+"{"+spinfo[0]+"}"
+                if k == "Cantrip":
+                    texT = texT + [slot_command_name]
+                    continue
+                slot_command_prep = slot_command+"Prepared"+"{"+str(spinfo[1])+"}"
+                texT = texT + [slot_command_name, slot_command_prep]
+            # Set remaining slots empty
+            for empty_slot in comp_letters[spells_this_level_and_page:slots_max]:
+                slot_command = "\\"+k+'Slot'+empty_slot
+                slot_command_name = slot_command+"{}"
+                if k == "Cantrip":
+                    texT = texT + [slot_command_name]
+                    continue
+                slot_command_prep = slot_command+"Prepared{False}"
+                texT = texT + [slot_command_name, slot_command_prep]
+            if (not len(spellList[k]) == 0
+                    and not spellList[k][0][0] == "--- Overflow ---"):
+                spellList[k].insert(0, ("--- Overflow ---", False))
+        return "\n".join(texT) + '\n\n' + spellsheet_command + '\n\n'
+
+    tex3 = ""
+    while any(spellList.values()):
+        tex3 = tex3 + AddSpellPage(fullcaster)
+    return "\n".join([tex1, tex2, tex3])
+
 
 def RPGtex_monster_info(char):
     """Generates the headings for the monster block info in the DND latex style"""

--- a/dungeonsheets/make_sheets.py
+++ b/dungeonsheets/make_sheets.py
@@ -516,7 +516,7 @@ def msavage_sheet(character, basename, debug=False):
             if re.search(r"" + character.portrait, str(image[0])):
                 character.images.remove(image)
                 break
-        portrait_command = r"\includegraphics[width=5.75cm]{" + character.portrait + "}"
+        portrait_command = r"{\centering \includegraphics[width=5.75cm,height=7.85cm,keepaspectratio]{" + character.portrait + "} \\\\ \\noindent}"
 
     # Move symbol image a bit left, if applicable
     if character.symbol:


### PR DESCRIPTION
These are five patches that together improve the quality of the latex character template and that bring the information on the latex character character sheet at the same level as the fillable sheets (except the proficiencies, but neither form if perfect at this point).

The first patch creates still more room in for equipment by putting weight and carrying capacity on one line instead of two.

The second patch improves portrait handling by better resizing pictures and keeping space for text as well.

The third patch lists all classes and levels on the character sheet, instead of only the primary class and level, just as the fillable sheet.

The fourth patch adds spell components information to the spell sheets, just as the fillable sheets.

The fifth patch introduces overflow spell pages, just as the fillable sheets.

These patches hinge on a recent change in the MSavage latex character sheet that introduces automatic font downsizing to prevent text box overflow. With all this, the latex character sheet is at feature parity with the fillable forms, barring proficiencies. I do have a separate branch for improving how proficiencies are dealt with on both the latex and fillable forms.