### PR TITLE
Proficiencies

### DIFF
--- a/dungeonsheets/background.py
+++ b/dungeonsheets/background.py
@@ -117,7 +117,7 @@ class RivalIntern(Background):
 
     name = "Rival Intern"
     skill_proficiencies = ("history", "investigation")
-    proficiencies_text = ("One type of artisan's tools",)
+    proficiencies_text = ("[choose one type of artisan's tools]",)
     languages = ("[choose one]",)
     features = (feats.InsideInformant,)
 

--- a/dungeonsheets/character.py
+++ b/dungeonsheets/character.py
@@ -851,17 +851,24 @@ class Character(Creature):
         # Backward compatibility with chosen_tools
         if not self.chosen_tools == "" :
             prof_set.update(self.chosen_tools.split(","))
-        # Extract "Other" proficiencies (artisan's tools, musical instruments, ... )
+        # Extract "Other" proficiencies (artisan's tools, musical instruments,
+        # ... ) and "Optional" proficiencies
         prof_dict["Other"] = []
+        prof_dict["Optional"] = []
         for prof in prof_set:
             if not (
                 # Anything other than weapons, armor, shields or options
                 any (re.search(w.name.lower(), prof) for w in w_pro)
                 or any (ar in prof for ar in armor_types)
                 or "shields" in prof
+                or r"[" in prof
             ):
                 prof_dict["Other"].append(prof)
+            elif r"[" in prof:
+                # Collect optional proficiencies
+                prof_dict["Optional"].append(prof)
         prof_dict["Other"] = ", ".join(prof_dict["Other"])
+        prof_dict["Optional"] = ", ".join(prof_dict["Optional"])
         # Nice capitalization
         prof_dict["Other"] = re.sub(r"[A-Za-z]+('[A-Za-z]+)?",
                                    lambda word: word.group(0).capitalize(),

--- a/dungeonsheets/character.py
+++ b/dungeonsheets/character.py
@@ -612,7 +612,10 @@ class Character(Creature):
                     self.magic_items.append(ThisMagicItem(wielder=self))
             elif attr == "weapon_proficiencies":
                 self.other_weapon_proficiencies = ()
-                msg = 'Magic Item "{}" not defined. Please add it to ``weapons.py``'
+                if r"[" in str(val):
+                    msg = 'Don\'t forget to choose optional proficiencies: "{}".'
+                else:
+                    msg = 'Magic Item "{}" not defined. Please add it to ``weapons.py``'
                 wps = set(
                     [
                         self._resolve_mechanic(

--- a/dungeonsheets/classes/artificer.py
+++ b/dungeonsheets/classes/artificer.py
@@ -89,7 +89,7 @@ class Artificer(CharClass):
         "Simple weapons",
         "Thieves' tools",
         "Tinker's tools",
-        "One type of artisan's tools of your choice",
+        "[Choose one type of artisan's tools]",
     )
     _multiclass_proficiencies_text = (
         "Light armor",

--- a/dungeonsheets/classes/bard.py
+++ b/dungeonsheets/classes/bard.py
@@ -158,7 +158,7 @@ class Bard(CharClass):
         "longswords",
         "rapiers",
         "shortswords",
-        "three musical instruments of your choice",
+        "[choose three musical instruments]",
     )
     weapon_proficiencies = (
         weapons.HandCrossbow,

--- a/dungeonsheets/classes/monk.py
+++ b/dungeonsheets/classes/monk.py
@@ -156,7 +156,7 @@ class Monk(CharClass):
         "simple weapons",
         "shortswords",
         "unarmed",
-        "one type of artisan's tools or one musical instrument",
+        "[choose one type of artisan's tools or one musical instrument]",
     )
     weapon_proficiencies = (weapons.Shortsword, weapons.Unarmed, weapons.SimpleWeapon)
     multiclass_weapon_proficiencies = weapon_proficiencies

--- a/dungeonsheets/create_character.py
+++ b/dungeonsheets/create_character.py
@@ -834,6 +834,20 @@ class SaveForm(LinkedListForm):
         self.make_pdf = self.add(npyscreen.Checkbox, name="Create PDF:", value=True)
 
     def on_ok(self):
+        # Finally, deal with some optional proficencies:
+        self.parentApp.character.proficiencies_text = ()
+        self.parentApp.character.optional_weapon_proficiencies = ()
+        optional_proficiencies = list(self.parentApp.character.proficiencies_by_type["Optional"].split(", "))
+        for prof in optional_proficiencies:
+            if "weapon" in prof:
+                self.parentApp.character.optional_weapon_proficiencies += (prof,)
+                log.debug(f"Optional weapon proficiencies: {self.parentApp.character.optional_weapon_proficiencies}")
+            elif "skill" in prof:
+                self.parentApp.character.skill_proficiencies += (prof,)
+                log.debug(f"Optional skill proficiencies: {self.parentApp.character.skill_proficiencies}")
+            else:
+                self.parentApp.character.proficiencies_text += (prof,)
+                log.debug(f"Other optional proficiencies: {self.parentApp.character.proficiencies_text}")
         super().to_next()
 
     def on_cancel(self):

--- a/dungeonsheets/fill_pdf_template.py
+++ b/dungeonsheets/fill_pdf_template.py
@@ -171,7 +171,7 @@ def create_character_pdf_template(character, basename, flatten=False):
     # Other proficiencies and languages
     prof_text = ""
     for prof_type, values in character.proficiencies_by_type.items():
-        if not values == "":
+        if not (prof_type == "Optional" or values == ""):
             prof_text += prof_type + ": " + values + ".\n\n"
     prof_text += "Languages: " + text_box(character.languages)
     fields["ProficienciesLang"] = prof_text

--- a/dungeonsheets/fill_pdf_template.py
+++ b/dungeonsheets/fill_pdf_template.py
@@ -143,7 +143,11 @@ def create_character_pdf_template(character, basename, flatten=False):
         try:
             fields[skill_boxes[skill.replace(" ", "_").lower()]] = CHECKBOX_ON
         except KeyError:
-            raise KeyError(f"Unknown skill: '{skill}'")
+            if r"[" in skill:
+                msg = f"You still have skills to select: '{skill}'"
+                warnings.warn(msg)
+            else:
+                raise KeyError(f"Unknown skill: '{skill}'")
     # Add weapons
     weapon_fields = [
         ("Wpn Name", "Wpn1 AtkBonus", "Wpn1 Damage"),

--- a/dungeonsheets/forms/MSavage_template.tex
+++ b/dungeonsheets/forms/MSavage_template.tex
@@ -180,7 +180,7 @@
 
 \OtherProficienciesLanguages{\textbf{Languages:} [[ char.languages ]]. \\
 [%- for prof_type, values in char.proficiencies_by_type.items() %]
-  [%- if not values == "": %]
+  [%- if not (prof_type == "Optional" or values == ""): %]
 \textbf{[[ prof_type ]]}: [[ values ]]. \\
   [%- endif -%]
 [%- endfor -%]

--- a/dungeonsheets/forms/character_sheet_template.html
+++ b/dungeonsheets/forms/character_sheet_template.html
@@ -112,8 +112,12 @@
 
 <h2 id="proficiencies">Proficiencies</h2>
 <dl class="proficiencies details">
-  <dt>Proficiencies</dt>
-  <dd>[[ character.proficiencies_text ]]</dd>
+  [% if character.proficiencies_by_type %][% for prof_type, values in character.proficiencies_by_type.items() %]
+  [%- if not (prof_type == "Optional" or values == ""): -%]
+  <dt>[[ prof_type ]]:<dt>
+  <dd>[[ values ]].</dd>
+  [% endif %]
+  [%- endfor -%][%- endif -%]
   <dt>Languages</dt>
   <dd>[[ character.languages ]]</dd>
 </dl>

--- a/dungeonsheets/forms/empty_template.txt
+++ b/dungeonsheets/forms/empty_template.txt
@@ -54,8 +54,8 @@ features = ()
 feature_choices = ()
 
 # Weapons/other proficiencies not given by class/race/background
-weapon_proficiencies = ()  # ex: ('shortsword', 'quarterstaff')
-proficiencies_text = ()  # ex: ("thieves' tools",)
+weapon_proficiencies = {{ char.optional_weapon_proficiencies }}  # ex: ('shortsword', 'quarterstaff')
+proficiencies_text = {{ char.proficiencies_text }}  # ex: ("thieves' tools",)
 
 # Proficiencies and languages
 languages = """{{ char.languages }}"""


### PR DESCRIPTION
This PR has five patches that affect how user-chosen proficiencies are listed and treated. The intended result is the same as with how languages are treated, as in  - if your background affords you an additional language, it is listed as [choose one] in your character file. Compare: "One type of artisan's tools", "Three musical instruments of your choice"

1. The first patch puts all user-chosen proficiency options in brackets and reformulates them as, e.g.,  [choose one type of artisan's tools]
2. The second patch separates such options in proficiencies_by_type into a separate category (from prof_dict["Other"] to prof_dict["Optional"])
3. The third patch prevents listing the user-chosen proficiencies in the dungeon-sheets output
4. The fourth patch makes sure that create_character adds user-chosen proficiencies to a character module.
5. The fifth and final patch adds a warning to makesheets that warns the user when they still have proficiencies to choose.

As end result, a user would, for instance, create a bard. This would add [choose three musical instruments] to the character file. When the user has not removed this choice and substituted it with three instruments, makesheets will warn that the user still needs to choose.