### PR TITLE
Code cleanups and cornercase bugfixes

### DIFF
--- a/docs/character_files.rst
+++ b/docs/character_files.rst
@@ -20,7 +20,7 @@ Each character file must contain a line like::
 
   dungeonsheets_version = "0.4.2"
 
-Without this line, the :ref:`makesheets` command-line utility will ignore
+Without this line, the :ref:`makesheets<Usage>` command-line utility will ignore
 the file. This is necessary to avoid importing non-D&D python files.
 
 .. note::

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -90,7 +90,7 @@ html_theme = 'nature'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/dungeonsheets/character.py
+++ b/dungeonsheets/character.py
@@ -556,7 +556,7 @@ class Character(Creature):
             spells |= set(f.spells_prepared)
         for c in self.spellcasting_classes:
             spells |= set(c.spells_prepared)
-        return sorted(tuple(spells), key=(lambda x: x.name))
+        return spells
 
     def set_attrs(self, **attrs):
         """
@@ -632,8 +632,6 @@ class Character(Creature):
                         warning_message=msg,
                     )
                     _spells.append(ThisSpell)
-                # Sort by name
-                _spells.sort(key=lambda spell: spell.name)
                 # Save list of spells to character atribute
                 if attr == "spells":
                     # Instantiate them all for the spells list

--- a/dungeonsheets/character.py
+++ b/dungeonsheets/character.py
@@ -451,32 +451,10 @@ class Character(Creature):
     @property
     def features(self):
         fts = set(self.custom_features)
-        fighting_style_defined = False
-        set_of_fighting_styles = {
-            "Fighting Style (Archery)",
-            "Fighting Style (Defense)",
-            "Fighting Style (Dueling)",
-            "Fighting Style (Great Weapon Fighting)",
-            "Fighting Style (Protection)",
-            "Fighting Style (Two-Weapon Fighting)",
-        }
-        for temp_feature in fts:
-            fighting_style_defined = temp_feature.name in set_of_fighting_styles
-            if fighting_style_defined:
-                break
-
         if not self.has_class:
             return fts
         for c in self.class_list:
             fts |= set(c.features)
-            for feature in fts:
-                if (
-                    fighting_style_defined
-                    and feature.name == "Fighting Style (Select One)"
-                ):
-                    temp_feature = feature
-                    fts.remove(temp_feature)
-                    break
         if self.race is not None:
             fts |= set(getattr(self.race, "features", ()))
             # some races have level-based features (Ex: Aasimar)

--- a/dungeonsheets/fill_pdf_template.py
+++ b/dungeonsheets/fill_pdf_template.py
@@ -306,7 +306,7 @@ def create_spells_pdf_template(character, basename, flatten=False):
     # Determine which sheet to use (caster or half-caster).
     # Prefer caster, unless we have no spells > 5th level and
     # would overflow the caster sheet, then use half-caster.
-    only_low_level = all((character.spell_slots(level) == 0 for level in range(6, 10)))
+    only_low_level = not any(spell.level > 5 for spell in character.spells)
     would_overflow_fullcaster = any(
         (
             len([spl for spl in character.spells if spl.level == level])

--- a/dungeonsheets/forms/preamble.tex
+++ b/dungeonsheets/forms/preamble.tex
@@ -109,7 +109,9 @@
 [% raw %]
 \usepackage{longtable,ltcaption,array}
 \setlength{\extrarowheight}{2pt}
-\newlength{\DUtablewidth} % internal use in tables
+% internal use in tables
+\newlength{\DUtablewidth}
+\newcommand{\DUcolumnwidth}[1]{\dimexpr#1\DUtablewidth-2\tabcolsep\relax}
 % admonition (specially marked topic)
 \providecommand{\DUadmonition}[2][class-arg]{%
   % try \DUadmonition#1{#2}:

--- a/dungeonsheets/latex.py
+++ b/dungeonsheets/latex.py
@@ -165,7 +165,7 @@ def latex_parts(
         "doctitle_xform": doctitle,
         "initial_header_level": initial_header_level,
         "use_latex_citations": True,
-        "legacy_column_widths": True,
+        "legacy_column_widths": False,
     }
     writer = LatexWriter()
     parts = core.publish_parts(
@@ -234,11 +234,9 @@ def rst_to_latex(rst, top_heading_level: int=0, format_dice: bool = True, use_dn
             transformed_header = header
             for width in colwidths:
                 # Transform the column width by dividing it by the initial table width
-                transformed_width = round( float(width) / tablewidth, 3)
-                # Subtract the table column separation spaces from the transformed column width
-                transformed_width = r"\\dimexpr " + str(transformed_width) + r"\\DUtablewidth -2\\tabcolsep"
+                transformed_width = str(round( float(width) / tablewidth, 3))
                 # Replace the original width with the transformed width
-                transformed_header = re.sub(width + r"\\DUtablewidth",
+                transformed_header = re.sub(width,
                                             transformed_width,
                                             transformed_header)
             # Replace the original table header with the transformed one

--- a/dungeonsheets/latex.py
+++ b/dungeonsheets/latex.py
@@ -248,7 +248,6 @@ def rst_to_latex(rst, top_heading_level: int=0, format_dice: bool = True, use_dn
         # Next, take the first table row and define it as the first page table header:
         tex = re.sub(r"(begin{DndLongTable}\[header=.*?)\](.*?)\n(.*?\\\\)\n\n",
                      r"\1,firsthead={\3 }]\2\n", tex, flags=re.M|re.DOTALL)
-
     return tex
 
 
@@ -323,9 +322,8 @@ def msavage_spell_info(char):
     # Only use halfcaster when we have no spells > 5th level and
     # would overflow the fullcaster sheet.
     # Keep the same sheet for overflow pages, if any.
-    only_low_level = all((char.spell_slots(level) == 0 for level in range(6, 10)))
     if (any(len(spellList[key]) > fullcaster_sheet_spaces[key] for key in spellList.keys())
-            and only_low_level):
+            and not any(name in spellList.keys() for name in level_names[6:10])):
         fullcaster = False
 
     def AddSpellPage(fullcaster = True):

--- a/dungeonsheets/latex.py
+++ b/dungeonsheets/latex.py
@@ -164,6 +164,8 @@ def latex_parts(
         "input_encoding": input_encoding,
         "doctitle_xform": doctitle,
         "initial_header_level": initial_header_level,
+        "use_latex_citations": True,
+        "legacy_column_widths": True,
     }
     writer = LatexWriter()
     parts = core.publish_parts(

--- a/dungeonsheets/make_sheets.py
+++ b/dungeonsheets/make_sheets.py
@@ -585,7 +585,6 @@ def make_character_sheet(
     char_base = basename + "_char"
     person_base = basename + "_person"
     sheets = [char_base + ".pdf"]
-    pages = []
     # Prepare the tex/html content
     content_suffix = format_suffixes[output_format]
     # Create a list of features and magic items
@@ -609,13 +608,11 @@ def make_character_sheet(
             char_pdf = create_character_pdf_template(
                 character=character, basename=char_base, flatten=flatten
             )
-            pages.append(char_pdf)
             person_pdf = create_personality_pdf_template(
                 character=character,
                 basename=person_base,
                 flatten=flatten,
             )
-            pages.append(person_pdf)
         if character.is_spellcaster and not (use_tex_template):
             # Create spell sheet
             spell_base = "{:s}_spells".format(basename)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ Homepage = "https://github.com/canismarko/dungeon-sheets"
 
 [tool.setuptools.package-data]
 dungeonsheets = [
-  "forms/*pdf",
+  "forms/*.html",
+  "forms/*.pdf",
   "forms/*.tex",
   "forms/*.txt",
   "modules/DND-5e-LaTeX-Template/*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,12 @@ authors = [
 ]
 description = "Dungeons and Dragons 5e Character Tools"
 readme = "README.rst"
-license = {"file"= "LICENSE"}
+license = "GPL-3.0-or-later"
+license-files = ["LICENSE"]
 requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Environment :: Console",
-  "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
   "Natural Language :: English",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
This PR includes a couple of fixes and some removal of unused / unnecessary code:

- No more docutils warnings
- Code removals include an unused variable, some unnecessary spell sorting, and fighting style in character.py
- Fixes to the halfcaster pages, where a small bug could cause the latex character template to crash (when adding a spell of a higher level than the character's highest level spell slot)
- Making sure to package all html forms, which otherwise might cause some tests to fail.