### PR TITLE
22-artificer-is-missing-the-armorer-specialization (#23)

### DIFF
--- a/dungeonsheets/classes/artificer.py
+++ b/dungeonsheets/classes/artificer.py
@@ -75,11 +75,32 @@ class BattleSmith(SubClass):
     features_by_level[15] = [features.ImprovedDefender]
 
 
+class Armorer(SubClass):
+    """An artificer who specializes as an Armorer modifies armor to function
+    almost like a second skin. The armor is enhanced to hone the artificer's
+    magic, unleash potent attacks, and generate a formidable defense. The
+    artificer bonds with this armor, becoming one with it even as they
+    experiment with it and refine its magical capabilities.
+    """
+
+    name = "Armorer"
+    features_by_level = defaultdict(list)
+    features_by_level[3] = [
+        features.ArmorerSpells,
+        features.ArmorerToolsOfTheTrade,
+        features.ArcaneArmor,
+        features.ArmorModel,
+    ]
+    features_by_level[5] = [features.ExtraAttackArmorer]
+    features_by_level[9] = [features.ArmorModifications]
+    features_by_level[15] = [features.PerfectedArmor]
+
+
 class Artificer(CharClass):
     name = "Artificer"
     hit_dice_faces = 8
     subclass_select_level = 3
-    subclasses_available = (Alchemist, Artillerist, BattleSmith)
+    subclasses_available = (Alchemist, Artillerist, BattleSmith, Armorer)
     saving_throw_proficiencies = ("intelligence", "constitution")
     primary_abilities = ("intelligence",)
     _proficiencies_text = (

--- a/dungeonsheets/features/artificer.py
+++ b/dungeonsheets/features/artificer.py
@@ -687,3 +687,157 @@ class ImprovedDefender(Feature):
 
     name = "Improved Defender"
     source = "Artificer (Battle Smith)"
+
+
+# Armorer
+class ArmorerSpells(_SpecialistSpells):
+    """You always have certain spells prepared after you reach particular levels
+    in this class, as shown in the Armorer Spells table. These spells count as
+    Artificer spells for you, but they don't count against the number of
+    Artificer spells you prepare.
+
+    """
+
+    _name = "Armorer"
+    _spells = {
+        3: [spells.Thunderwave, spells.MagicMissile],
+        5: [spells.MirrorImage, spells.Shatter],
+        9: [spells.HypnoticPattern, spells.LightningBolt],
+        13: [spells.FireShield, spells.GreaterInvisibility],
+        17: [spells.Passwall, spells.WallOfForce],
+    }
+
+
+class ArmorerToolsOfTheTrade(Feature):
+    """You gain proficiency with heavy armor. You also gain proficiency with
+    smith's tools. If you already have this tool proficiency, you gain
+    proficiency with one other type of artisan's tools of your choice.
+
+    """
+
+    name = "Tools of the Trade"
+    source = "Artificer (Armorer)"
+
+
+class ArcaneArmor(Feature):
+    """Your metallurgical pursuits have led to you making armor a conduit for
+    your magic. As an action, you can turn a suit of armor you are wearing into
+    Arcane Armor, provided you have smith's tools in hand. You gain the
+    following benefits while wearing this armor:
+
+    - If the armor normally has a Strength requirement, the arcane armor lacks
+      this requirement for you.
+    - You can use the arcane armor as a spellcasting focus for your Artificer
+      spells.
+    - The armor attaches to you and can't be removed against your will. It also
+      expands to cover your entire body, although you can retract or deploy the
+      helmet as a bonus action. The armor replaces any missing limbs,
+      functioning identically to a limb it replaces.
+    - You can doff or don the armor as an action.
+
+    The armor continues to be Arcane Armor until you don another suit of armor
+    or you die.
+
+    """
+
+    name = "Arcane Armor"
+    source = "Artificer (Armorer)"
+
+
+class ArmorModel(Feature):
+    """You can customize your Arcane Armor. When you do so, choose one of the
+    following armor models: Guardian or Infiltrator. The model you choose gives
+    you special benefits while you wear it.
+
+    Each model includes a special weapon. When you attack with that weapon, you
+    can add your Intelligence modifier, instead of Strength or Dexterity, to the
+    attack and damage rolls.
+
+    You can change the armor's model whenever you finish a short or long rest,
+    provided you have smith's tools in hand.
+
+    Guardian. You design your armor to be in the front line of conflict. It has
+    the following features:
+
+    - Thunder Gauntlets. Each of the armor's gauntlets counts as a simple melee
+      weapon while you aren't holding anything in it, and it deals ld8 thunder
+      damage on a hit. A creature hit by the gauntlet has disadvantage on attack
+      rolls against targets other than you until the start of your next turn, as
+      the armor magically emits a distracting pulse when the creature attacks
+      someone else.
+    - Defensive Field. As a bonus action, you can gain temporary hit points
+      equal to your level in this class, replacing any temporary hit points you
+      already have. You lose these temporary hit points if you doff the armor.
+      You can use this bonus action a number of times equal to your proficiency
+      bonus, and you regain all expended uses when you finish a long rest.
+
+    Infiltrator. You customize your armor for subtle undertakings. It has the
+    following features:
+
+    - Lightning Launcher. A gemlike node appears on one of your armored fists or
+      on the chest (your choice). It counts as a simple ranged weapon, with a
+      normal range of 90 feet and a long range of 300 feet, and it deals ld6
+      lightning damage on a hit. Once on each of your turns when you hit a
+      creature with it, you can deal an extra ld6 lightning damage to that
+      target.
+    - Powered Steps. Your walking speed increases by 5 feet.
+    - Dampening Field. You have advantage on Dexterity (Stealth) checks. If the
+      armor normally imposes disadvantage on such checks, the advantage and
+      disadvantage cancel each other, as normal.
+
+    """
+
+    name = "Armor Model"
+    source = "Artificer (Armorer)"
+
+
+class ExtraAttackArmorer(Feature):
+    """You can attack twice, rather than once, whenever you take the Attack
+    action on your turn
+
+    """
+
+    name = "Extra Attack"
+    source = "Artificer (Armorer)"
+
+
+class ArmorModifications(Feature):
+    """At 9th level, you learn how to use your artificer infusions to specially
+    modify your Arcane Armor. That armor now counts as separate items for the
+    purposes of your Infuse Items feature: armor (the chest piece), boots,
+    helmet, and the armor's special weapon. Each of those items can bear one of
+    your infusions, and the infusions transfer over if you change your armor's
+    model with the Armor Model feature. In addition, the maximum number of items
+    you can infuse at once increases by 2, but those extra items must be part of
+    your Arcane Armor.
+
+    """
+
+    name = "Armor Modifications"
+    source = "Artificer (Armorer)"
+
+
+class PerfectedArmor(Feature):
+    """At 15th level, your Arcane Armor gains additional benefits based on its
+    model, as shown below.
+
+    Guardian. When a Huge or smaller creature you can see ends its turn within
+    30 feet of you, you can use your reaction to magically force the creature to
+    make a Strength saving throw against your spell save DC, pulling the
+    creature up to 30 feet toward you to an unoccupied space. If you pull the
+    target to a space within 5 feet of you, you can make a melee weapon attack
+    against it as part of this reaction. You can use this reaction a number of
+    times equal to your proficiency bonus, and you regain all expended uses of
+    it when you finish a long rest.
+
+    Infiltrator. Any creature that takes lightning damage from your Lightning
+    Launcher glimmers with magical light until the start of your next turn. The
+    glimmering creature sheds dim light in a 5-foot radius, and it has
+    disadvantage on attack rolls against you, as the light jolts it if it
+    attacks you. In addition, the next attack roll against it has advantage, and
+    if that attack hits, the target takes an extra ld6 lightning damage.
+
+    """
+
+    name = "Perfected Armor"
+    source = "Artificer (Armorer)"

--- a/dungeonsheets/infusions.py
+++ b/dungeonsheets/infusions.py
@@ -101,7 +101,18 @@ class HomunculusServant(Infusion):
 
     name = "Homunculus Servant"
     item = "A gem worth at least 100gp or a dragonshard"
-    prerequisite = "6th-level artificer"
+
+
+class MindSharpener(Infusion):
+    """The infused item can send a jolt to the wearer to refocus their mind. The
+    item has 4 charges. When the wearer fails a Constitution saving throw to
+    maintain concentration on a spell, the wearer can use its reaction to expend
+    1 of the item's charges to succeed instead. The item regains ld4 expended
+    charges daily at dawn.
+    """
+
+    name = "Mind Sharpener"
+    item = "A suit of armor or robes"
 
 
 class RadiantWeapon(Infusion):

--- a/examples/artificer3.py
+++ b/examples/artificer3.py
@@ -1,0 +1,124 @@
+"""This file describes the heroic adventurer Zemcack.
+
+It's used primarily for saving characters from create-character, where there
+will be many missing sections.
+
+Modify this file as you level up and then re-generate the character
+sheet by running ``makesheets`` from the command line.
+
+"""
+
+dungeonsheets_version = "0.10.1"
+
+name = "Zemcack"
+player_name = "Teste McTestface"
+
+# Be sure to list Primary class first
+classes = ['Artificer']  # ex: ['Wizard'] or ['Rogue', 'Fighter']
+levels = [20]  # ex: [10] or [3, 2]
+subclasses = ['Armorer']  # ex: ['Necromancy'] or ['Thief', None]
+background = "Sailor"
+race = "Rock Gnome"
+alignment = "Neutral good"
+
+xp = "Milestone"
+hp_max = 149
+inspiration = 0  # integer inspiration value
+
+# Ability Scores
+strength = 13
+dexterity = 16
+constitution = 18
+intelligence = 20
+wisdom = 12
+charisma = 10
+
+# Select what skills you're proficient with
+# ex: skill_proficiencies = ('athletics', 'acrobatics', 'arcana')
+skill_proficiencies = ('investigation', 'sleight of hand',
+                       'athletics', 'perception')
+
+# Any skills you have "expertise" (Bard/Rogue) in
+skill_expertise = ()
+
+# Named features / feats that aren't part of your classes, race, or background.
+# Also include Eldritch Invocations and features you make multiple selection of
+# (like Maneuvers for Fighter, Metamagic for Sorcerers, Trick Shots for
+# Gunslinger, etc.)
+# Example:
+# features = ('Tavern Brawler',) # take the optional Feat from PHB
+features = ('sharpshooter')
+
+# If selecting among multiple feature options: ex Fighting Style
+# Example (Fighting Style):
+# feature_choices = ('Archery',)
+feature_choices = ()
+
+# Weapons/other proficiencies not given by class/race/background
+weapon_proficiencies = ()  # ex: ('shortsword', 'quarterstaff')
+proficiencies_text = ()  # ex: ("thieves' tools",)
+
+# Proficiencies and languages
+languages = """Common, Gnomish"""
+
+# Inventory
+# TODO: Get yourself some money
+cp = 0
+sp = 0
+ep = 0
+gp = 0
+pp = 0
+
+# TODO: Put your equipped weapons and armor here
+weapons = []  # Example: ('shortsword', 'longsword')
+magic_items = ()  # Example: ('ring of protection',)
+armor = "Breastplate"  # Eg "leather armor"
+shield = "None"  # Eg "shield"
+
+equipment = """TODO: list the equipment and magic items your character carries"""
+
+attacks_and_spellcasting = """TODO: Describe how your character usually attacks
+or uses spells."""
+
+# List of known spells
+# Example: spells_prepared = ('magic missile', 'mage armor')
+spells_prepared = ()  # Todo: Learn some spells
+
+# Which spells have not been prepared
+__spells_unprepared = ()
+
+# all spells known
+spells = spells_prepared + __spells_unprepared
+
+# Wild shapes for Druid
+wild_shapes = ()  # Ex: ('ape', 'wolf', 'ankylosaurus')
+
+# Infusions for Artificer
+infusions = (
+    'boots of the winding path',
+    'enhanced arcane focus',
+    'enhanced defense',
+    'enhanced weapon',
+    'repeating shot',
+    'homunculus servant',
+    'mind sharpener',
+    'radiant weapon',
+    'replicate magic item',
+    'repulsion shield',
+    'resistant armor',
+    'returning weapon'
+)
+# Ex: ('repeating shot', 'replicate magic item')
+
+# Backstory
+# Describe your backstory here
+personality_traits = """TODO: Describe how your character behaves, interacts with others"""
+
+ideals = """TODO: Describe what values your character believes in."""
+
+bonds = """TODO: Describe your character's commitments or ongoing quests."""
+
+flaws = """TODO: Describe your character's interesting flaws."""
+
+features_and_traits = """TODO: Describe other features and abilities your
+character has."""

--- a/tests/test_weapon.py
+++ b/tests/test_weapon.py
@@ -16,6 +16,7 @@ class WeaponTestCase(unittest.TestCase):
 
 class MagicWeaponTestCase(unittest.TestCase):
     """Check that a magic weapon works as intended."""
+
     def test_class_inheritance_weapon_first(self):
         """Test that the class inheritance works correctly for multiclassing."""
         MagicWeapon = type("MagicWeapon", (Weapon, MagicItem),
@@ -26,7 +27,7 @@ class MagicWeaponTestCase(unittest.TestCase):
         self.assertEqual(weapon.damage, "1d4+2")
         # Check some magic item traits
         self.assertEqual(weapon.st_bonus_all, 3)
-    
+
     def test_class_inheritance_magic_item_first(self):
         """Test that the class inheritance works correctly for multiclassing."""
         MagicWeapon = type("MagicWeapon", (MagicItem, Weapon),


### PR DESCRIPTION
* Added **Armorer** specialization for **Artificer** class and features.

* Added example armorer, heroic adventurer Zemcack, and updated tests.

* Removed erroneous requirement for 6th-level from Homunculus Servant infusion. Added Mind Sharpener infusion to definitions and example artificer file.

Fixes #185 